### PR TITLE
Modernize codebase, unify variable names...

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.70
+current_version = 0.3.71
 
 [bumpversion:file:mdpo/__init__.py]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     hooks:
       - id: trailing-whitespace
         name: trailing-whitespace
+        exclude: test/test_po2md/translate-examples/code-blocks.*
       - id: end-of-file-fixer
         name: end-of-file-fixer
       - id: double-quote-string-fixer

--- a/docs/pre-commit-hooks.rst
+++ b/docs/pre-commit-hooks.rst
@@ -15,7 +15,7 @@ so you don't need to specify them.
 .. code-block:: yaml
 
    - repo: https://github.com/mondeja/mdpo
-     rev: v0.3.70
+     rev: v0.3.71
      hooks:
        - id: md2po
          args:
@@ -43,7 +43,7 @@ po2md
 .. code-block:: yaml
 
    - repo: https://github.com/mondeja/mdpo
-     rev: v0.3.70
+     rev: v0.3.71
      hooks:
        - id: po2md
          args:
@@ -56,7 +56,7 @@ po2md
 .. code-block:: yaml
 
    - repo: https://github.com/mondeja/mdpo
-     rev: v0.3.70
+     rev: v0.3.71
      hooks:
        - id: po2md
          files: README\.md
@@ -75,7 +75,7 @@ md2po2md
 .. code-block:: yaml
 
    - repo: https://github.com/mondeja/mdpo
-     rev: v0.3.70
+     rev: v0.3.71
      hooks:
        - id: md2po2md
          args:
@@ -88,7 +88,7 @@ md2po2md
 .. code-block:: yaml
 
    - repo: https://github.com/mondeja/mdpo
-     rev: v0.3.70
+     rev: v0.3.71
      hooks:
        - id: md2po2md
          files: README\.md

--- a/mdpo/__init__.py
+++ b/mdpo/__init__.py
@@ -6,7 +6,7 @@ from mdpo.mdpo2html import markdown_pofile_to_html
 from mdpo.po2md import pofile_to_markdown
 
 
-__version__ = '0.3.70'
+__version__ = '0.3.71'
 __title__ = 'mdpo'
 __description__ = ('Markdown files translation using PO files.')
 __all__ = (

--- a/mdpo/event.py
+++ b/mdpo/event.py
@@ -36,7 +36,7 @@ def _block_msg(block, details):
     return block.name
 
 
-def debug_events(program):  # pragma: no cover
+def debug_events(program):
     """Debugging events for interfaces. Displays in STDOUT all event targets.
 
     Args:

--- a/mdpo/html.py
+++ b/mdpo/html.py
@@ -18,9 +18,9 @@ def html_attrs_tuple_to_string(attrs):
     """
     response = ''
     for i, (name, value) in enumerate(attrs):
-        response += '%s' % name
+        response += name
         if value is not None:
-            response += '="%s"' % value
+            response += f'="{value}"'
         if i < len(attrs) - 1:
             response += ' '
     return response

--- a/mdpo/md.py
+++ b/mdpo/md.py
@@ -418,10 +418,10 @@ def solve_link_reference_targets(translations):
         # store in solutions
         solutions[new_msgid] = new_msgstr
 
-        # print("----> new_msgid", new_msgid)
-        # print("----> new_msgstr", new_msgstr)
+        # print('----> new_msgid', new_msgid)
+        # print('----> new_msgstr', new_msgstr)
 
-    # print("----> link_references_text_targets", link_references_text_targets)
-    # print("----> msgid_msgstrs_with_links", msgid_msgstrs_with_links)
-    # print("----> solutions", solutions)
+    # print('----> link_references_text_targets', link_references_text_targets)
+    # print('----> msgid_msgstrs_with_links', msgid_msgstrs_with_links)
+    # print('----> solutions', solutions)
     return solutions

--- a/mdpo/md.py
+++ b/mdpo/md.py
@@ -46,9 +46,8 @@ def escape_links_titles(text, link_start_string='[', link_end_string=']'):
 
     for match in re.findall(regex, text):
         original_string = match[0] + match[1]
-        target_string = match[0] + '"%s"' % (
-            match[1][1:-1].replace('"', '\\"')
-        )
+        escaped_title = match[1][1:-1].replace('"', '\\"')
+        target_string = f'{match[0]}"{escaped_title}"'
         text = text.replace(original_string, target_string)
     return text
 

--- a/mdpo/md2po/__init__.py
+++ b/mdpo/md2po/__init__.py
@@ -10,7 +10,11 @@ from mdpo.command import (
     parse_mdpo_html_command,
 )
 from mdpo.event import debug_events, raise_skip_event
-from mdpo.io import filter_paths, to_glob_or_content
+from mdpo.io import (
+    filter_paths,
+    save_file_checking_file_changed,
+    to_glob_or_content,
+)
 from mdpo.md import parse_link_references
 from mdpo.md4c import (
     DEFAULT_MD4C_GENERIC_PARSER_EXTENSIONS,
@@ -21,7 +25,6 @@ from mdpo.po import (
     mark_not_found_entries_as_obsoletes,
     po_escaped_string,
     remove_not_found_entries,
-    save_pofile_checking_file_changed,
 )
 from mdpo.text import min_not_max_chars_in_a_row, parse_wrapwidth_argument
 
@@ -967,9 +970,10 @@ class Md2Po:
 
         if save and po_filepath:
             if self._saved_files_changed is False:  # pragma: no cover
-                self._saved_files_changed = save_pofile_checking_file_changed(
-                    self.pofile,
+                self._saved_files_changed = save_file_checking_file_changed(
                     po_filepath,
+                    str(self.pofile),
+                    encoding=self.pofile.encoding,
                 )
             else:
                 self.pofile.save(fpath=po_filepath)

--- a/mdpo/md2po/__init__.py
+++ b/mdpo/md2po/__init__.py
@@ -785,10 +785,9 @@ class Md2Po:
                     self._current_imgspan['text'],
                     self._current_imgspan['src'],
                 )
-                if self._current_imgspan['title']:
-                    self._current_msgid += ' "%s"' % (
-                        self._current_imgspan['title']
-                    )
+                title = self._current_imgspan['title']
+                if title:
+                    self._current_msgid += f' "{title}"'
                 self._current_msgid += ')'
                 self._current_imgspan = {}
             elif span is md4c.SpanType.U:

--- a/mdpo/md2po/__init__.py
+++ b/mdpo/md2po/__init__.py
@@ -784,15 +784,30 @@ class Md2Po:
                     )
                 self._codespan_backticks = None
             elif span is md4c.SpanType.IMG:
-                self._current_msgid += '![{}]({}'.format(
-                    self._current_imgspan['text'],
-                    self._current_imgspan['src'],
-                )
-                title = self._current_imgspan['title']
-                if title:
-                    self._current_msgid += f' "{title}"'
-                self._current_msgid += ')'
-                self._current_imgspan = {}
+                # TODO: refactor with getattr? Currently getting next error
+                # getattr(self, target_varname) += '![{}]({}'.format(
+                # SyntaxError: cannot assign to function call
+
+                if not self._inside_aspan:
+                    self._current_msgid += '![{}]({}'.format(
+                        self._current_imgspan['text'],
+                        self._current_imgspan['src'],
+                    )
+                    title = self._current_imgspan['title']
+                    if title:
+                        self._current_msgid += f' "{title}"'
+                    self._current_msgid += ')'
+                    self._current_imgspan = {}
+                else:
+                    self._current_aspan_text += '![{}]({}'.format(
+                        self._current_imgspan['text'],
+                        self._current_imgspan['src'],
+                    )
+                    title = self._current_imgspan['title']
+                    if title:
+                        self._current_aspan_text += f' "{title}"'
+                    self._current_aspan_text += ')'
+                    self._current_imgspan = {}
             elif span is md4c.SpanType.U:
                 self._inside_uspan = False
 

--- a/mdpo/md2po/__init__.py
+++ b/mdpo/md2po/__init__.py
@@ -1033,8 +1033,7 @@ def markdown_to_pofile(
                 for you. It depends on the use you are going to give to
                 this library activate this mode (``plaintext=False``) or not.
         wrapwidth (int): Wrap width for po file indicated at ``po_filepath``
-            parameter. Only useful when the ``-w`` option was passed
-            to xgettext. If negative, 0, 'inf' or 'math.inf' the content won't
+            parameter. If negative, 0, 'inf' or 'math.inf' the content won't
             be wrapped.
         mark_not_found_as_obsolete (bool): The strings extracted from markdown
             that will not be found inside the provided pofile will be marked

--- a/mdpo/md2po/__init__.py
+++ b/mdpo/md2po/__init__.py
@@ -1034,7 +1034,8 @@ def markdown_to_pofile(
                 this library activate this mode (``plaintext=False``) or not.
         wrapwidth (int): Wrap width for po file indicated at ``po_filepath``
             parameter. Only useful when the ``-w`` option was passed
-            to xgettext.
+            to xgettext. If negative, 0, 'inf' or 'math.inf' the content won't
+            be wrapped.
         mark_not_found_as_obsolete (bool): The strings extracted from markdown
             that will not be found inside the provided pofile will be marked
             as obsolete.

--- a/mdpo/md2po/__init__.py
+++ b/mdpo/md2po/__init__.py
@@ -172,7 +172,7 @@ class Md2Po:
         self._include_next_codeblock = False
         self._disable_next_codeblock = False
 
-        self._saved_files_changed = (  # pragma: no cover
+        self._saved_files_changed = (
             False if kwargs.get('_check_saved_files_changed') else None
         )
 

--- a/mdpo/md2po/__main__.py
+++ b/mdpo/md2po/__main__.py
@@ -204,7 +204,7 @@ def run(args=[]):
         pofile = md2po.extract(**extract_kwargs)
 
         if not opts.quiet:
-            sys.stdout.write(pofile.__unicode__() + '\n')
+            sys.stdout.write(f'{str(pofile)}\n')
 
         # pre-commit mode
         if (  # pragma: no cover

--- a/mdpo/md2po/__main__.py
+++ b/mdpo/md2po/__main__.py
@@ -76,8 +76,7 @@ def build_parser():
         '-w', '--wrapwidth', dest='wrapwidth', metavar='N/inf', type=str,
         default='78',
         help='Wrap width for po file indicated at \'-po/--po-filepath\''
-             ' parameter. Only useful when the \'-w\' option was passed to'
-             ' xgettext. If negative, \'0\' or \'inf\', the PO file content'
+             ' parameter. If negative, \'0\' or \'inf\', the PO file content'
              ' will not be wrapped.',
     )
     parser.add_argument(

--- a/mdpo/md2po/__main__.py
+++ b/mdpo/md2po/__main__.py
@@ -204,7 +204,7 @@ def run(args=[]):
         pofile = md2po.extract(**extract_kwargs)
 
         if not opts.quiet:
-            sys.stdout.write(f'{str(pofile)}\n')
+            sys.stdout.write(f'{pofile}\n')
 
         # pre-commit mode
         if (  # pragma: no cover

--- a/mdpo/md2po/__main__.py
+++ b/mdpo/md2po/__main__.py
@@ -206,9 +206,7 @@ def run(args=[]):
             sys.stdout.write(f'{pofile}\n')
 
         # pre-commit mode
-        if (  # pragma: no cover
-            opts.check_saved_files_changed and md2po._saved_files_changed
-        ):
+        if opts.check_saved_files_changed and md2po._saved_files_changed:
             return (pofile, 1)
 
     return (pofile, 0)

--- a/mdpo/md2po/__main__.py
+++ b/mdpo/md2po/__main__.py
@@ -77,8 +77,8 @@ def build_parser():
         default='78',
         help='Wrap width for po file indicated at \'-po/--po-filepath\''
              ' parameter. Only useful when the \'-w\' option was passed to'
-             ' xgettext. You can use the values \'0\' and \'inf\' for infinite'
-             ' width.',
+             ' xgettext. If negative, \'0\' or \'inf\', the PO file content'
+             ' will not be wrapped.',
     )
     parser.add_argument(
         '-m', '--merge-po-files', '--merge-pofiles',

--- a/mdpo/md2po2md/__init__.py
+++ b/mdpo/md2po2md/__init__.py
@@ -139,9 +139,7 @@ def markdown_to_pofile_to_markdown(
                 po_encoding=po_encoding,
                 md_encoding=md_encoding,
             )
-            if (  # pragma: no cover
-                _check_saved_files_changed and _saved_files_changed is False
-            ):
+            if _check_saved_files_changed and _saved_files_changed is False:
                 _saved_files_changed = md2po._saved_files_changed
 
             # po2md
@@ -158,9 +156,7 @@ def markdown_to_pofile_to_markdown(
                 save=md_filepath,
                 md_encoding=md_encoding,
             )
-            if (  # pragma: no cover
-                _check_saved_files_changed and _saved_files_changed is False
-            ):
+            if _check_saved_files_changed and _saved_files_changed is False:
                 _saved_files_changed = po2md._saved_files_changed
 
     return _saved_files_changed

--- a/mdpo/md2po2md/__init__.py
+++ b/mdpo/md2po2md/__init__.py
@@ -108,9 +108,9 @@ def markdown_to_pofile_to_markdown(
 
             os.makedirs(os.path.abspath(po_dirpath), exist_ok=True)
             if os.path.isdir(po_filepath):
-                po_filepath = (
-                    po_filepath.rstrip(os.sep) + os.sep +
-                    os.path.basename(filepath) + '.po'
+                po_filepath = os.path.join(
+                    po_filepath.rstrip(os.sep),
+                    f'{os.path.basename(filepath)}.po',
                 )
             if not po_filepath.endswith('.po'):
                 po_filepath += '.po'

--- a/mdpo/md2po2md/__main__.py
+++ b/mdpo/md2po2md/__main__.py
@@ -112,9 +112,7 @@ def run(args=[]):
             _check_saved_files_changed=opts.check_saved_files_changed,
             **kwargs,
         )
-        if (  # pragma: no cover
-            opts.check_saved_files_changed and _saved_files_changed
-        ):
+        if opts.check_saved_files_changed and _saved_files_changed:
             exitcode = 1
     return exitcode
 

--- a/mdpo/mdpo2html/__init__.py
+++ b/mdpo/mdpo2html/__init__.py
@@ -143,7 +143,7 @@ class MdPo2HTML(HTMLParser):
                     raw_html_template += '<{}{}>'.format(
                         handled,
                         (
-                            ' ' + html_attrs_tuple_to_string(attrs)
+                            f' {html_attrs_tuple_to_string(attrs)}'
                             if attrs else ''
                         ),
                     )
@@ -152,7 +152,7 @@ class MdPo2HTML(HTMLParser):
                     raw_html_template += '<{}{}>'.format(
                         handled,
                         (
-                            ' ' + html_attrs_tuple_to_string(attrs)
+                            f' {html_attrs_tuple_to_string(attrs)}'
                             if attrs else ''
                         ),
                     )
@@ -161,25 +161,24 @@ class MdPo2HTML(HTMLParser):
                     raw_html_template += '<{}{}>'.format(
                         handled,
                         (
-                            ' ' + html_attrs_tuple_to_string(attrs)
+                            f' {html_attrs_tuple_to_string(attrs)}'
                             if attrs else ''
                         ),
                     )
                 elif handled in self.link_tags:
                     title = get_html_attrs_tuple_attr(attrs, 'title')
-                    _current_link_target += '(%s' % get_html_attrs_tuple_attr(
-                        attrs, 'href',
-                    )
+                    href = get_html_attrs_tuple_attr(attrs, 'href')
+                    _current_link_target += f'({href}'
                     if title:
-                        _current_link_target += ' "%s"' % title
+                        _current_link_target += f' "{title}"'
                     _current_link_target += ')'
 
-                    raw_html_template += '<%s' % handled
+                    raw_html_template += f'<{handled}'
 
                     # attrs_except_href_title = []
                     for attr, value in attrs:
                         if attr in ['title', 'href']:
-                            raw_html_template += ' %s="{}"' % attr
+                            raw_html_template += f' {attr}="{{}}"'
                         # else:
                         #     These attributes are not included in output
                         #    attrs_except_href_title.append((attr, value))
@@ -191,7 +190,7 @@ class MdPo2HTML(HTMLParser):
                 else:
                     raw_html_template += '<{}{}>'.format(
                         handled,
-                        ' ' + html_attrs_tuple_to_string(attrs)
+                        f' {html_attrs_tuple_to_string(attrs)}'
                         if attrs else '',
                     )
                 _last_start_tag = handled
@@ -215,7 +214,7 @@ class MdPo2HTML(HTMLParser):
                     else:
                         _current_replacement += handled
             elif handle == 'end':
-                raw_html_template += '</%s>' % handled
+                raw_html_template += f'</{handled}>'
                 if handled in self.code_tags:
                     _current_replacement += '`'
                 elif handled in self.bold_tags:
@@ -226,7 +225,7 @@ class MdPo2HTML(HTMLParser):
                 if _last_end_tag == 'code':
                     _inside_code = False
             elif handle == 'comment':
-                raw_html_template += '<!--%s-->' % handled
+                raw_html_template += f'<!--{handled}-->'
             elif handle == 'startend':
                 if handled in self.image_tags:
                     _current_replacement += '![{}]({}'.format(
@@ -235,7 +234,7 @@ class MdPo2HTML(HTMLParser):
                     )
                     title = get_html_attrs_tuple_attr(attrs, 'title')
                     if title:
-                        _current_replacement += ' "%s"' % title
+                        _current_replacement += f' "{title}"'
                     _current_replacement += ')'
 
                     raw_html_template += '{}'
@@ -243,7 +242,7 @@ class MdPo2HTML(HTMLParser):
                     raw_html_template += '<{}{}/>'.format(
                         handled,
                         (
-                            (' %s' % html_attrs_tuple_to_string(attrs))
+                            f' {html_attrs_tuple_to_string(attrs)}'
                             if attrs else ''
                         ),
                     )
@@ -280,7 +279,7 @@ class MdPo2HTML(HTMLParser):
 
         # print("RAW TEMPLATE:", raw_html_template)
         # print("TEMPLATE TAGS:", template_tags)
-        # print('CURRENT MSGID: \'%s\'' % _current_replacement)
+        # print(f'CURRENT MSGID: \'{_current_replacement}\'')
         # print('MSGSTR:', replacement)
 
         html_before_first_replacement = raw_html_template.split('{')[0]
@@ -288,9 +287,9 @@ class MdPo2HTML(HTMLParser):
         for tags_group in [self.bold_tags, self.italic_tags, self.code_tags]:
             for tag in tags_group:
                 html_before_first_replacement = \
-                    html_before_first_replacement.split('<%s>' % tag)[0]
+                    html_before_first_replacement.split(f'<{tag}>')[0]
                 html_after_last_replacement = \
-                    html_after_last_replacement.split('</%s>' % tag)[-1]
+                    html_after_last_replacement.split(f'</{tag}>')[-1]
             html_before_first_replacement = \
                 html_before_first_replacement.split('<a href="')[0]
 
@@ -319,24 +318,24 @@ class MdPo2HTML(HTMLParser):
         # print("________________________________________________")
 
     def handle_starttag(self, tag, attrs):
-        # print("START TAG: %s | POS: %d:%d" % (tag, *self.getpos()))
+        # print('START TAG: %s | POS: %d:%d' % (tag, *self.getpos()))
 
         if tag in self.ignore_grouper_tags:
             self.context.append(tag)
             self.output += '<{}{}>'.format(
-                tag, ' ' + html_attrs_tuple_to_string(attrs) if attrs else '',
+                tag, f' {html_attrs_tuple_to_string(attrs)}' if attrs else '',
             )
         elif self.context and self.context[0] in self.ignore_grouper_tags:
             self.output += '<{}{}>'.format(
-                tag, ' ' + html_attrs_tuple_to_string(attrs) if attrs else '',
+                tag, f' {html_attrs_tuple_to_string(attrs)}' if attrs else '',
             )
         elif tag == 'ul' and not self.context:
             self.output += '<{}{}>'.format(
-                tag, ' ' + html_attrs_tuple_to_string(attrs) if attrs else '',
+                tag, f' {html_attrs_tuple_to_string(attrs)}' if attrs else '',
             )
         elif tag in ['blockquote', 'table', 'thead', 'tbody', 'tr']:
             self.output += '<{}{}>'.format(
-                tag, ' ' + html_attrs_tuple_to_string(attrs) if attrs else '',
+                tag, f' {html_attrs_tuple_to_string(attrs)}' if attrs else '',
             )
         else:
             if tag == 'a' and self.real_link_reference_targets is None:
@@ -354,16 +353,16 @@ class MdPo2HTML(HTMLParser):
         # print("END TAG: %s | POS: %d:%d" % (tag, *self.getpos()))
 
         if tag in self.ignore_grouper_tags:
-            self.output += '</%s>' % tag
+            self.output += f'</{tag}>'
             if self.context:
                 self.context.pop()
         elif self.context and self.context[0] in self.ignore_grouper_tags:
-            self.output += '</%s>' % tag
+            self.output += f'</{tag}>'
         elif tag in PROCESS_REPLACER_TAGS:
             self.replacer.append(('end', tag, None))
             self._process_replacer()
         elif tag in ['ul', 'blockquote', 'tr', 'table', 'thead', 'tbody']:
-            self.output += '</%s>' % tag
+            self.output += f'</{tag}>'
         else:
             self.replacer.append(('end', tag, None))
             if self.context:
@@ -378,7 +377,7 @@ class MdPo2HTML(HTMLParser):
             self.replacer.append(('startend', tag, attrs))
 
     def handle_data(self, data):
-        # print("     DATA: '%s'" % (data))
+        # print(f'     DATA: \'{data}\'')
 
         if data:
             if not self.replacer or (
@@ -394,7 +393,7 @@ class MdPo2HTML(HTMLParser):
                 self.replacer.append(('data', data, None))
 
     def handle_comment(self, data):
-        # print("     COMMENT: '%s'" % (data))
+        # print(f'     COMMENT: \'{data}\'')
 
         if self.replacer:
             self.replacer.append(('comment', data, None))

--- a/mdpo/mdpo2html/__init__.py
+++ b/mdpo/mdpo2html/__init__.py
@@ -123,7 +123,7 @@ class MdPo2HTML(HTMLParser):
             self.output = '\n'.join(split_output)[:-1]
 
     def _process_replacer(self):
-        # print("REPLACER:", self.replacer)
+        # print('REPLACER:', self.replacer)
 
         template_tags = []
         raw_html_template, _current_replacement = ('', '')
@@ -277,8 +277,8 @@ class MdPo2HTML(HTMLParser):
                         if tag not in template_tags:
                             template_tags.append(tag)
 
-        # print("RAW TEMPLATE:", raw_html_template)
-        # print("TEMPLATE TAGS:", template_tags)
+        # print('RAW TEMPLATE:', raw_html_template)
+        # print('TEMPLATE TAGS:', template_tags)
         # print(f'CURRENT MSGID: \'{_current_replacement}\'')
         # print('MSGSTR:', replacement)
 
@@ -315,7 +315,7 @@ class MdPo2HTML(HTMLParser):
         self._enable_next_line = False
         self._current_msgctxt = None
 
-        # print("________________________________________________")
+        # print('________________________________________________')
 
     def handle_starttag(self, tag, attrs):
         # print('START TAG: %s | POS: %d:%d' % (tag, *self.getpos()))
@@ -350,7 +350,7 @@ class MdPo2HTML(HTMLParser):
             self.context.append(tag)
 
     def handle_endtag(self, tag):
-        # print("END TAG: %s | POS: %d:%d" % (tag, *self.getpos()))
+        # print('END TAG: %s | POS: %d:%d' % (tag, *self.getpos()))
 
         if tag in self.ignore_grouper_tags:
             self.output += f'</{tag}>'
@@ -369,7 +369,7 @@ class MdPo2HTML(HTMLParser):
                 self.context.pop()
 
     def handle_startendtag(self, tag, attrs):
-        # print("STARTEND TAG: %s | POS: %d:%d" % (tag, *self.getpos()))
+        # print('STARTEND TAG: %s | POS: %d:%d' % (tag, *self.getpos()))
 
         if not self.replacer:
             self.output += self.get_starttag_text()

--- a/mdpo/mdpo2html/__main__.py
+++ b/mdpo/mdpo2html/__main__.py
@@ -103,7 +103,7 @@ def run(args=[]):
         )
 
         if not opts.quiet and not opts.save:
-            sys.stdout.write(output + '\n')
+            sys.stdout.write(f'{output}\n')
 
     return (output, 0)
 

--- a/mdpo/po.py
+++ b/mdpo/po.py
@@ -21,7 +21,7 @@ def po_escaped_string(chars):
     Returns:
         str: First character of passed string with ``\`` character prepended.
     """
-    return '\\' + chars[0]
+    return f'\\{chars[0]}'
 
 
 def find_entry_in_entries(entry, entries, **kwargs):

--- a/mdpo/po.py
+++ b/mdpo/po.py
@@ -1,11 +1,10 @@
 """``.po`` files related stuff."""
 
 import glob
-import os
 
 import polib
 
-from mdpo.io import filehash, filter_paths
+from mdpo.io import filter_paths
 from mdpo.polib import poentry__cmp__
 
 
@@ -162,24 +161,3 @@ def paths_or_globs_to_unique_pofiles(pofiles_globs, ignore, po_encoding=None):
                 _po_filepaths.append(po_filepath)
 
     return pofiles
-
-
-def save_pofile_checking_file_changed(pofile, po_filepath):
-    """Save a :py:class:`polib.POFile` checking if the content has changed.
-
-    Args:
-        pofile (:py:class:`polib.POFile`): POFile to save.
-        po_filepath (str): Path to the new file to save in.
-
-    Returns:
-        bool: If the PO file content has been changed.
-    """
-    if not os.path.isfile(po_filepath):
-        pofile.save(fpath=po_filepath)
-        return True
-
-    pre_hash = filehash(po_filepath)
-    pofile.save(fpath=po_filepath)
-    post_hash = filehash(po_filepath)
-
-    return pre_hash != post_hash

--- a/mdpo/po2md/__init__.py
+++ b/mdpo/po2md/__init__.py
@@ -794,14 +794,28 @@ class Po2Md:
             )
             self._codespan_backticks = None
         elif span is md4c.SpanType.IMG:
-            self._current_msgid += '![{}]({}'.format(
-                self._current_imgspan['text'],
-                self._current_imgspan['src'],
-            )
-            if self._current_imgspan['title']:
-                title = self._current_imgspan['title']
-                self._current_msgid += f' "{title}"'
-            self._current_msgid += ')'
+            # TODO: refactor with getattr? Currently getting next error
+            # getattr(self, target_varname) += '![{}]({}'.format(
+            # SyntaxError: cannot assign to function call
+
+            if not self._inside_aspan:
+                self._current_msgid += '![{}]({}'.format(
+                    self._current_imgspan['text'],
+                    self._current_imgspan['src'],
+                )
+                if self._current_imgspan['title']:
+                    title = self._current_imgspan['title']
+                    self._current_msgid += f' "{title}"'
+                self._current_msgid += ')'
+            else:
+                self._current_aspan_text += '![{}]({}'.format(
+                    self._current_imgspan['text'],
+                    self._current_imgspan['src'],
+                )
+                if self._current_imgspan['title']:
+                    title = self._current_imgspan['title']
+                    self._current_aspan_text += f' "{title}"'
+                self._current_aspan_text += ')'
             self._current_imgspan = {}
 
     def text(self, block, text):

--- a/mdpo/po2md/__init__.py
+++ b/mdpo/po2md/__init__.py
@@ -360,8 +360,6 @@ class Po2Md:
         if self._inside_indented_codeblock:
             new_translation = ''
             for line in translation.splitlines():
-                if not line:
-                    continue
                 new_translation += f'    {line}\n'
             translation = new_translation
         else:

--- a/mdpo/po2md/__init__.py
+++ b/mdpo/po2md/__init__.py
@@ -153,7 +153,7 @@ class Po2Md:
             ) if 'wrapwidth' in kwargs else 80
         )
 
-        self._saved_files_changed = (  # pragma: no cover
+        self._saved_files_changed = (
             False if kwargs.get('_check_saved_files_changed') else None
         )
 
@@ -421,7 +421,7 @@ class Po2Md:
 
     def enter_block(self, block, details):
         # raise 'enter_block' event
-        if raise_skip_event(  # pragma: no cover
+        if raise_skip_event(
             self.events,
             'enter_block',
             self, block,
@@ -530,7 +530,7 @@ class Po2Md:
 
     def leave_block(self, block, details):
         # raise 'leave_block' event
-        if raise_skip_event(  # pragma: no cover
+        if raise_skip_event(
             self.events,
             'leave_block',
             self,
@@ -673,7 +673,7 @@ class Po2Md:
 
     def enter_span(self, span, details):
         # raise 'enter_span' event
-        if raise_skip_event(  # pragma: no cover
+        if raise_skip_event(
             self.events,
             'enter_span',
             self,
@@ -733,7 +733,7 @@ class Po2Md:
 
     def leave_span(self, span, details):
         # raise 'leave_span' event
-        if raise_skip_event(  # pragma: no cover
+        if raise_skip_event(
             self.events,
             'leave_span',
             self,
@@ -808,7 +808,7 @@ class Po2Md:
 
     def text(self, block, text):
         # raise 'text' event
-        if raise_skip_event(  # pragma: no cover
+        if raise_skip_event(
             self.events,
             'text',
             self,
@@ -940,7 +940,7 @@ class Po2Md:
         self.output = '\n'.join(self._outputlines)
 
         if save:
-            if self._saved_files_changed is False:  # pragma: no cover
+            if self._saved_files_changed is False:
                 self._saved_files_changed = save_file_checking_file_changed(
                     save,
                     self.output,

--- a/mdpo/po2md/__init__.py
+++ b/mdpo/po2md/__init__.py
@@ -459,7 +459,8 @@ class Po2Md:
                 self._save_current_line()
         elif block is md4c.BlockType.H:
             self._inside_hblock = True
-            self._current_line += '%s ' % ('#' * details['level'])
+            hash_signs = '#' * details['level']
+            self._current_line += f'{hash_signs} '
         elif block is md4c.BlockType.LI:
             if self._current_list_type[-1][0] == 'ol':
                 # inside OL
@@ -480,7 +481,8 @@ class Po2Md:
                     self._ul_marks[-1],
                 )
                 if details['is_task']:
-                    self._current_line += '[%s] ' % details['task_mark']
+                    mark = details['task_mark']
+                    self._current_line += f'[{mark}] '
                 self._current_list_type[-1][-1].append(details['is_task'])
             self._inside_liblock = True
             self._inside_liblock_first_p = True
@@ -799,9 +801,8 @@ class Po2Md:
                 self._current_imgspan['src'],
             )
             if self._current_imgspan['title']:
-                self._current_msgid += ' "%s"' % polib.escape(
-                    self._current_imgspan['title'],
-                )
+                title = self._current_imgspan['title']
+                self._current_msgid += f' "{title}"'
             self._current_msgid += ')'
             self._current_imgspan = {}
 

--- a/mdpo/po2md/__main__.py
+++ b/mdpo/po2md/__main__.py
@@ -120,9 +120,7 @@ def run(args=[]):
             sys.stdout.write(f'{output}\n')
 
         # pre-commit mode
-        if (  # pragma: no cover
-            opts.check_saved_files_changed and po2md._saved_files_changed
-        ):
+        if opts.check_saved_files_changed and po2md._saved_files_changed:
             return (output, 1)
 
     return (output, 0)

--- a/mdpo/po2md/__main__.py
+++ b/mdpo/po2md/__main__.py
@@ -117,7 +117,7 @@ def run(args=[]):
         )
 
         if not opts.quiet and not opts.save:
-            sys.stdout.write(output + '\n')
+            sys.stdout.write(f'{output}\n')
 
         # pre-commit mode
         if (  # pragma: no cover

--- a/mdpo/po2md/__main__.py
+++ b/mdpo/po2md/__main__.py
@@ -59,8 +59,8 @@ def build_parser():
     )
     parser.add_argument(
         '-w', '--wrapwidth', dest='wrapwidth', default='80', type=str,
-        help='Maximum width rendering the Markdown output, when possible. You'
-             ' can use the values \'0\' and \'inf\' for infinite width.',
+        help='Maximum width rendering the Markdown output, when possible. If'
+             ' negative, \'0\' or \'inf\', the content will not be wrapped.',
         metavar='N/inf',
     )
     add_encoding_arguments(parser)

--- a/mdpo/text.py
+++ b/mdpo/text.py
@@ -114,7 +114,7 @@ def parse_strint_0_inf(value):
     """
     num = float(value)
     try:
-        return int(num) if num != 0 else math.inf
+        return int(num) if num > 0 else math.inf
     except OverflowError:  # cannot convert float infinity to integer
         return math.inf
 

--- a/mdpo/text.py
+++ b/mdpo/text.py
@@ -127,7 +127,7 @@ def parse_wrapwidth_argument(value):
     """
     try:
         value = parse_strint_0_inf(value)
-    except ValueError as err:  # pragma: no cover
+    except ValueError as err:
         if os.environ.get('_MDPO_RUNNING'):  # executed as CLI
             sys.stderr.write(
                 f"Invalid value '{err.value}' for -w/--wrapwidth argument.\n",

--- a/mdpo/text.py
+++ b/mdpo/text.py
@@ -112,13 +112,11 @@ def parse_strint_0_inf(value):
     Args:
         value (str): Value to parse.
     """
+    num = float(value)
     try:
-        num = int(value)
-    except ValueError:
-        if value.lower() == 'inf':
-            return math.inf
-        raise ValueError(value)
-    return num if num else math.inf
+        return int(num) if num != 0 else math.inf
+    except OverflowError:  # cannot convert float infinity to integer
+        return math.inf
 
 
 def parse_wrapwidth_argument(value):
@@ -129,8 +127,8 @@ def parse_wrapwidth_argument(value):
     """
     try:
         value = parse_strint_0_inf(value)
-    except ValueError as err:
-        if os.environ.get('_MDPO_RUNNING'):
+    except ValueError as err:  # pragma: no cover
+        if os.environ.get('_MDPO_RUNNING'):  # executed as CLI
             sys.stderr.write(
                 f"Invalid value '{err.value}' for -w/--wrapwidth argument.\n",
             )
@@ -160,7 +158,7 @@ def removeprefix(text, prefix):
         return text.removeprefix(prefix)
     if text.startswith(prefix):
         return text[len(prefix):]
-    return text  # pragma: no cover
+    return text
 
 
 def removesuffix(text, suffix):
@@ -183,4 +181,4 @@ def removesuffix(text, suffix):
         return text.removesuffix(suffix)
     if suffix and text.endswith(suffix):
         return text[:-len(suffix)]
-    return text  # pragma: no cover
+    return text

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mdpo
-version = 0.3.70
+version = 0.3.71
 description = Markdown files translation using PO files.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,21 +18,3 @@ def _tmp_file(content, suffix):
 @pytest.fixture()
 def tmp_file():
     return _tmp_file
-
-
-@pytest.fixture()
-def striplastline():
-    """Returns a text, ignoring the last line.
-
-    Args:
-        text (str): Text that will be returned ignoring its last line.
-
-    Returns:
-        str: Text wihout their last line.
-    """
-    def _striplastline(text):
-        stripped_text = '\n'.join(text.split('\n')[:-1])
-        if len(stripped_text) == len(text):
-            raise Exception('Unnecessary use of \'striplastline\' fixture')
-        return stripped_text
-    return _striplastline

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,13 +6,10 @@ import pytest
 
 @contextmanager
 def _tmp_file(content, suffix):
-    f = tempfile.NamedTemporaryFile(suffix=suffix)
-    f.write(content.encode('utf-8'))
-    f.seek(0)
-    try:
+    with tempfile.NamedTemporaryFile(suffix=suffix) as f:
+        f.write(content.encode('utf-8'))
+        f.seek(0)
         yield f.name
-    finally:
-        f.close()
 
 
 @pytest.fixture()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -23,7 +23,8 @@ from mdpo.cli import parse_command_aliases_cli_arguments
             None,
             (
                 "The value 'foobar' passed to argument --command-alias"
-                " can't be parsed."
+                " can't be parsed. Please, separate the pair"
+                " '<custom-command:mdpo-command>' with a ':' character.\n"
             ),
             id='foobar-error: unparsed alias resolution',
         ),
@@ -32,7 +33,7 @@ from mdpo.cli import parse_command_aliases_cli_arguments
             None,
             (
                 "Multiple resolutions for 'foo' alias passed to"
-                ' --command-alias arguments.'
+                ' --command-alias arguments.\n'
             ),
             id='foo:bar,foo:baz-error: multiple resolutions for alias',
         ),
@@ -47,8 +48,9 @@ def test_parse_command_aliases_cli_arguments(
     if expected_stderr:
         with pytest.raises(SystemExit):
             parse_command_aliases_cli_arguments(command_aliases)
-        _, stderr = capsys.readouterr()
-        assert expected_stderr in stderr
+        stdout, stderr = capsys.readouterr()
+        assert stderr == expected_stderr
+        assert stdout == ''
     else:
         assert parse_command_aliases_cli_arguments(
             command_aliases,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -47,8 +47,8 @@ def test_parse_command_aliases_cli_arguments(
     if expected_stderr:
         with pytest.raises(SystemExit):
             parse_command_aliases_cli_arguments(command_aliases)
-        out, err = capsys.readouterr()
-        assert expected_stderr in err
+        _, stderr = capsys.readouterr()
+        assert expected_stderr in stderr
     else:
         assert parse_command_aliases_cli_arguments(
             command_aliases,

--- a/test/test_md2po/extract-examples/markuptext/images.md
+++ b/test/test_md2po/extract-examples/markuptext/images.md
@@ -9,3 +9,9 @@
 [id]: url/to/image  "Optional title attribute"
 
 My ![foo bar](/path/to/train.jpg "title")
+
+[![Image inside inline link](https://image.ext)](https://link.ext)
+
+[![Image inside referenced link](https://image.ext)][1]
+
+[1]: https://link-1.ext

--- a/test/test_md2po/extract-examples/markuptext/images.md.expect.po
+++ b/test/test_md2po/extract-examples/markuptext/images.md.expect.po
@@ -16,3 +16,17 @@ msgstr ""
 
 msgid "My ![foo bar](/path/to/train.jpg \"title\")"
 msgstr ""
+
+msgid "[![Image inside inline link](https://image.ext)](https://link.ext)"
+msgstr ""
+
+msgid "[![Image inside referenced link](https://image.ext)][1]"
+msgstr ""
+
+#, fuzzy
+msgid "[id]: url/to/image \"Optional title attribute\""
+msgstr "[id]: url/to/image \"Optional title attribute\""
+
+#, fuzzy
+msgid "[1]: https://link-1.ext"
+msgstr "[1]: https://link-1.ext"

--- a/test/test_md2po/test_commands/test_md2po_codeblocks.py
+++ b/test/test_md2po/test_commands/test_md2po_codeblocks.py
@@ -21,7 +21,7 @@ This must be included also.
     var thisCodeMustNotBeIncluded = undefined;
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -50,7 +50,7 @@ var thisCodeMustNotBeIncluded = undefined;
 ```
 '''
     pofile = markdown_to_pofile(content)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -88,7 +88,7 @@ var thisCodeMustBeIncluded = undefined;
         command_aliases=command_aliases,
         include_codeblocks=True,
     )
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -125,7 +125,7 @@ var thisCodeMustBeIncluded = undefined;
         command_aliases=command_aliases,
         include_codeblocks=True,
     )
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -164,7 +164,7 @@ var thisCodeMustBeIncluded = undefined;
         command_aliases=command_aliases,
         include_codeblocks=False,
     )
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_codeblocks.py
+++ b/test/test_md2po/test_commands/test_md2po_codeblocks.py
@@ -21,7 +21,7 @@ This must be included also.
     var thisCodeMustNotBeIncluded = undefined;
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -50,7 +50,7 @@ var thisCodeMustNotBeIncluded = undefined;
 ```
 '''
     pofile = markdown_to_pofile(content)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -88,7 +88,7 @@ var thisCodeMustBeIncluded = undefined;
         command_aliases=command_aliases,
         include_codeblocks=True,
     )
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -125,7 +125,7 @@ var thisCodeMustBeIncluded = undefined;
         command_aliases=command_aliases,
         include_codeblocks=True,
     )
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -164,7 +164,7 @@ var thisCodeMustBeIncluded = undefined;
         command_aliases=command_aliases,
         include_codeblocks=False,
     )
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_context.py
+++ b/test/test_md2po/test_commands/test_md2po_context.py
@@ -17,7 +17,7 @@ May
 May
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_context.py
+++ b/test/test_md2po/test_commands/test_md2po_context.py
@@ -17,7 +17,7 @@ May
 May
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_disable.py
+++ b/test/test_md2po/test_commands/test_md2po_disable.py
@@ -28,7 +28,7 @@ This must be ignored
 This must be included also.
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -53,7 +53,7 @@ def test_disable_enable_raw_inline():
 This must be included also.
 '''
     pofile = markdown_to_pofile(content)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -94,7 +94,7 @@ The last line also must be included.
 '''
 
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -131,7 +131,7 @@ This must be ignored also.
 This must be included also.
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_disable.py
+++ b/test/test_md2po/test_commands/test_md2po_disable.py
@@ -28,7 +28,7 @@ This must be ignored
 This must be included also.
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -53,7 +53,7 @@ def test_disable_enable_raw_inline():
 This must be included also.
 '''
     pofile = markdown_to_pofile(content)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -94,7 +94,7 @@ The last line also must be included.
 '''
 
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -131,7 +131,7 @@ This must be ignored also.
 This must be included also.
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_include.py
+++ b/test/test_md2po/test_commands/test_md2po_include.py
@@ -16,7 +16,7 @@ Some text that needs to be clarified
 Some text without comment
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -53,7 +53,7 @@ Some text that needs to be clarified
 Some text without comment
 '''
     pofile = markdown_to_pofile(content)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 
@@ -78,7 +78,7 @@ Some text that needs to be clarified
 Some text without comment
 '''
     pofile = markdown_to_pofile(content)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_include.py
+++ b/test/test_md2po/test_commands/test_md2po_include.py
@@ -16,7 +16,7 @@ Some text that needs to be clarified
 Some text without comment
 '''
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -53,7 +53,7 @@ Some text that needs to be clarified
 Some text without comment
 '''
     pofile = markdown_to_pofile(content)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 
@@ -78,7 +78,7 @@ Some text that needs to be clarified
 Some text without comment
 '''
     pofile = markdown_to_pofile(content)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_translator.py
+++ b/test/test_md2po/test_commands/test_md2po_translator.py
@@ -17,7 +17,7 @@ Some text without comment
 '''
 
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_commands/test_md2po_translator.py
+++ b/test/test_md2po/test_commands/test_md2po_translator.py
@@ -17,7 +17,7 @@ Some text without comment
 '''
 
     pofile = markdown_to_pofile(content, command_aliases=command_aliases)
-    assert pofile.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_extract.py
+++ b/test/test_md2po/test_extract.py
@@ -14,7 +14,7 @@ EXAMPLES_DIR = os.path.join('test', 'test_md2po', 'extract-examples')
 
 def _build_examples(dirname):
     examples_dir = os.path.join(EXAMPLES_DIR, dirname)
-    examples_glob = glob.glob(examples_dir + os.sep + '*.md')
+    examples_glob = glob.glob(os.path.join(examples_dir, '*.md'))
     examples_filenames = sorted(os.path.basename(fp) for fp in examples_glob)
     return (examples_dir, examples_filenames)
 
@@ -33,8 +33,8 @@ def test_extract_plaintext(filename):
     filepath = os.path.join(EXAMPLES['plaintext']['dirpath'], filename)
     pofile = markdown_to_pofile(filepath, plaintext=True, location=False)
 
-    with open(filepath + '.expect.po') as expect_file:
-        assert pofile.__unicode__() == expect_file.read()
+    with open(f'{filepath}.expect.po') as expect_file:
+        assert str(pofile) == expect_file.read()
 
 
 @pytest.mark.parametrize('filename', EXAMPLES['markuptext']['filenames'])
@@ -42,8 +42,8 @@ def test_extract_markuptext(filename):
     filepath = os.path.join(EXAMPLES['markuptext']['dirpath'], filename)
     pofile = markdown_to_pofile(filepath, plaintext=False, location=False)
 
-    with open(filepath + '.expect.po') as expect_file:
-        assert pofile.__unicode__() == expect_file.read()
+    with open(f'{filepath}.expect.po') as expect_file:
+        assert str(pofile) == expect_file.read()
 
 
 @pytest.mark.parametrize('filename', EXAMPLES['underline']['filenames'])
@@ -56,8 +56,8 @@ def test_extract_underline(filename):
         location=False,
     )
 
-    with open(filepath + '.expect.po') as expect_file:
-        assert pofile.__unicode__() == expect_file.read()
+    with open(f'{filepath}.expect.po') as expect_file:
+        assert str(pofile) == expect_file.read()
 
 
 @pytest.mark.parametrize(
@@ -77,6 +77,6 @@ def test_extract_save(filename):
     )
     save_file.seek(0)
 
-    with open(filepath + '.expect.po') as expect_file:
+    with open(f'{filepath}.expect.po') as expect_file:
         assert save_file.read().decode('utf-8') == expect_file.read()
     save_file.close()

--- a/test/test_md2po/test_extract.py
+++ b/test/test_md2po/test_extract.py
@@ -34,7 +34,7 @@ def test_extract_plaintext(filename):
     pofile = markdown_to_pofile(filepath, plaintext=True, location=False)
 
     with open(f'{filepath}.expect.po') as expect_file:
-        assert str(pofile) == expect_file.read()
+        assert pofile == expect_file.read()
 
 
 @pytest.mark.parametrize('filename', EXAMPLES['markuptext']['filenames'])
@@ -43,7 +43,7 @@ def test_extract_markuptext(filename):
     pofile = markdown_to_pofile(filepath, plaintext=False, location=False)
 
     with open(f'{filepath}.expect.po') as expect_file:
-        assert str(pofile) == expect_file.read()
+        assert pofile == expect_file.read()
 
 
 @pytest.mark.parametrize('filename', EXAMPLES['underline']['filenames'])
@@ -57,7 +57,7 @@ def test_extract_underline(filename):
     )
 
     with open(f'{filepath}.expect.po') as expect_file:
-        assert str(pofile) == expect_file.read()
+        assert pofile == expect_file.read()
 
 
 @pytest.mark.parametrize(

--- a/test/test_md2po/test_extract.py
+++ b/test/test_md2po/test_extract.py
@@ -66,17 +66,15 @@ def test_extract_underline(filename):
 def test_extract_save(filename):
     filepath = os.path.join(EXAMPLES['plaintext']['dirpath'], filename)
 
-    save_file = tempfile.NamedTemporaryFile(suffix='.po')
+    with tempfile.NamedTemporaryFile(suffix='.po') as save_file:
 
-    markdown_to_pofile(
-        filepath,
-        plaintext=True,
-        save=True,
-        po_filepath=save_file.name,
-        location=False,
-    )
-    save_file.seek(0)
+        markdown_to_pofile(
+            filepath,
+            plaintext=True,
+            save=True,
+            po_filepath=save_file.name,
+            location=False,
+        )
 
-    with open(f'{filepath}.expect.po') as expect_file:
-        assert save_file.read().decode('utf-8') == expect_file.read()
-    save_file.close()
+        with open(f'{filepath}.expect.po') as expect_file:
+            assert save_file.read().decode('utf-8') == expect_file.read()

--- a/test/test_md2po/test_extract.py
+++ b/test/test_md2po/test_extract.py
@@ -34,7 +34,7 @@ def test_extract_plaintext(filename):
     pofile = markdown_to_pofile(filepath, plaintext=True, location=False)
 
     with open(f'{filepath}.expect.po') as expect_file:
-        assert pofile == expect_file.read()
+        assert str(pofile) == expect_file.read()
 
 
 @pytest.mark.parametrize('filename', EXAMPLES['markuptext']['filenames'])
@@ -43,7 +43,7 @@ def test_extract_markuptext(filename):
     pofile = markdown_to_pofile(filepath, plaintext=False, location=False)
 
     with open(f'{filepath}.expect.po') as expect_file:
-        assert pofile == expect_file.read()
+        assert str(pofile) == expect_file.read()
 
 
 @pytest.mark.parametrize('filename', EXAMPLES['underline']['filenames'])
@@ -57,7 +57,7 @@ def test_extract_underline(filename):
     )
 
     with open(f'{filepath}.expect.po') as expect_file:
-        assert pofile == expect_file.read()
+        assert str(pofile) == expect_file.read()
 
 
 @pytest.mark.parametrize(

--- a/test/test_md2po/test_extractor.py
+++ b/test/test_md2po/test_extractor.py
@@ -34,12 +34,12 @@ def test_mark_not_found_as_obsolete(tmp_file):
         'Another string\n\n'
     )
     new_md_file_content = 'A new string\n'
-    po_file = tempfile.NamedTemporaryFile(suffix='.po')
 
-    with tmp_file(original_md_file_content, '.md') as original_md_filepath:
-        md2po = Md2Po(original_md_filepath)
-        pofile = md2po.extract(po_filepath=po_file.name, save=True)
-    assert str(pofile) == f'''#
+    with tempfile.NamedTemporaryFile(suffix='.po') as po_file:
+        with tmp_file(original_md_file_content, '.md') as original_md_filepath:
+            md2po = Md2Po(original_md_filepath)
+            pofile = md2po.extract(po_filepath=po_file.name, save=True)
+        assert str(pofile) == f'''#
 msgid ""
 msgstr ""
 
@@ -52,13 +52,13 @@ msgid "Another string"
 msgstr ""
 '''
 
-    with tmp_file(new_md_file_content, '.md') as new_md_filepath:
-        md2po = Md2Po(
-            new_md_filepath,
-            mark_not_found_as_obsolete=True,
-        )
-        pofile = md2po.extract(po_filepath=po_file.name)
-    assert str(pofile) == f'''#
+        with tmp_file(new_md_file_content, '.md') as new_md_filepath:
+            md2po = Md2Po(
+                new_md_filepath,
+                mark_not_found_as_obsolete=True,
+            )
+            pofile = md2po.extract(po_filepath=po_file.name)
+        assert str(pofile) == f'''#
 msgid ""
 msgstr ""
 
@@ -72,8 +72,6 @@ msgstr ""
 #~ msgid "Another string"
 #~ msgstr ""
 '''
-
-    po_file.close()
 
 
 def test_msgstr():

--- a/test/test_md2po/test_extractor.py
+++ b/test/test_md2po/test_extractor.py
@@ -16,7 +16,7 @@ code block
 '''
 
     md2po = Md2Po(markdown_content)
-    assert md2po.extract().__unicode__() == '''#
+    assert str(md2po.extract()) == '''#
 msgid ""
 msgstr ""
 
@@ -38,8 +38,8 @@ def test_mark_not_found_as_obsolete(tmp_file):
 
     with tmp_file(original_md_file_content, '.md') as original_md_filepath:
         md2po = Md2Po(original_md_filepath)
-        po = md2po.extract(po_filepath=po_file.name, save=True)
-    assert po.__unicode__() == f'''#
+        pofile = md2po.extract(po_filepath=po_file.name, save=True)
+    assert str(pofile) == f'''#
 msgid ""
 msgstr ""
 
@@ -57,8 +57,8 @@ msgstr ""
             new_md_filepath,
             mark_not_found_as_obsolete=True,
         )
-        po = md2po.extract(po_filepath=po_file.name)
-    assert po.__unicode__() == f'''#
+        pofile = md2po.extract(po_filepath=po_file.name)
+    assert str(pofile) == f'''#
 msgid ""
 msgstr ""
 
@@ -79,7 +79,7 @@ msgstr ""
 def test_msgstr():
     content = 'Mensaje por defecto'
     md2po = Md2Po(content, msgstr='Default message')
-    assert md2po.extract(content).__unicode__() == '''#
+    assert str(md2po.extract(content)) == '''#
 msgid ""
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr "Default message"
 def test_ignore_msgids():
     content = 'foo\n\nbar\n\nbaz\n'
     md2po = Md2Po(content, ignore_msgids=['foo', 'baz'])
-    assert md2po.extract(content).__unicode__() == '''#
+    assert str(md2po.extract(content)) == '''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_extractor.py
+++ b/test/test_md2po/test_extractor.py
@@ -39,7 +39,7 @@ def test_mark_not_found_as_obsolete(tmp_file):
         with tmp_file(original_md_file_content, '.md') as original_md_filepath:
             md2po = Md2Po(original_md_filepath)
             pofile = md2po.extract(po_filepath=po_file.name, save=True)
-        assert str(pofile) == f'''#
+        assert pofile == f'''#
 msgid ""
 msgstr ""
 
@@ -58,7 +58,7 @@ msgstr ""
                 mark_not_found_as_obsolete=True,
             )
             pofile = md2po.extract(po_filepath=po_file.name)
-        assert str(pofile) == f'''#
+        assert pofile == f'''#
 msgid ""
 msgstr ""
 

--- a/test/test_md2po/test_md2po_cli.py
+++ b/test/test_md2po/test_md2po_cli.py
@@ -33,7 +33,7 @@ def test_stdin(striplastline, capsys, monkeypatch):
     pofile, exitcode = run()
     out, err = capsys.readouterr()
     assert exitcode == 0
-    assert pofile.__unicode__() == EXAMPLE['output']
+    assert str(pofile) == EXAMPLE['output']
     assert striplastline(out) == EXAMPLE['output']
 
 
@@ -81,7 +81,7 @@ def test_quiet(capsys, arg):
     out, err = capsys.readouterr()
 
     assert exitcode == 0
-    assert pofile.__unicode__() == EXAMPLE['output']
+    assert str(pofile) == EXAMPLE['output']
     assert out == ''
 
 
@@ -91,7 +91,7 @@ def test_debug(capsys, arg):
     out, err = capsys.readouterr()
 
     assert exitcode == 0
-    assert pofile.__unicode__() == EXAMPLE['output']
+    assert str(pofile) == EXAMPLE['output']
 
     po_output_checked = False
 
@@ -144,7 +144,7 @@ msgstr ""
         out, err = capsys.readouterr()
 
     assert exitcode == 0
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
     assert striplastline(out) == expected_output
 
 
@@ -183,7 +183,7 @@ msgstr ""
             assert f.read() == expected_output
 
     assert exitcode == 0
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
     assert striplastline(out) == expected_output
 
     # new PO file creation
@@ -209,7 +209,7 @@ msgstr ""
         assert f.read() == expected_output
 
     assert exitcode == 0
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
     assert striplastline(out) == expected_output
 
 
@@ -222,7 +222,7 @@ def test_mo_filepath(striplastline, capsys, arg):
     pofile, exitcode = run([EXAMPLE['input'], arg, mo_filepath])
     out, err = capsys.readouterr()
     assert exitcode == 0
-    assert pofile.__unicode__() == EXAMPLE['output']
+    assert str(pofile) == EXAMPLE['output']
     assert striplastline(out) == EXAMPLE['output']
     assert os.path.exists(mo_filepath)
 
@@ -239,7 +239,7 @@ def test_ignore_files_by_filepath(striplastline, capsys, arg):
 
     with tempfile.TemporaryDirectory() as filesdir:
         for filename, content in filesdata.items():
-            filepath = os.path.join(filesdir, filename + '.md')
+            filepath = os.path.join(filesdir, f'{filename}.md')
             with open(filepath, 'w') as f:
                 f.write(content)
 
@@ -265,7 +265,7 @@ msgid "Foo 2"
 msgstr ""
 '''
     assert exitcode == 0
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
     assert striplastline(out) == expected_output
 
 
@@ -293,7 +293,7 @@ msgstr ""
 '''
 
     assert exitcode == 0
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
     assert striplastline(out) == expected_output
 
 
@@ -316,7 +316,7 @@ msgid "Some long header with bold characters, italic characters and a link."
 msgstr ""
 '''
     assert exitcode == 0
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
     assert striplastline(out) == expected_output
 
 
@@ -350,7 +350,7 @@ msgstr ""
 '''
 
     assert exitcode == 0
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
     assert striplastline(out) == expected_output
 
 
@@ -384,7 +384,7 @@ msgstr ""
 
     assert exitcode == 0
     assert striplastline(out) == expected_output
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
 
 
 @pytest.mark.parametrize('arg', ['--ignore-msgids'])
@@ -403,7 +403,7 @@ msgstr ""
 
     assert exitcode == 0
     assert striplastline(out) == expected_output
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
 
 
 @pytest.mark.parametrize('arg', ['--command-alias'])
@@ -437,7 +437,7 @@ msgstr ""
 
     assert exitcode == 0
     assert striplastline(out) == expected_output
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
 
 
 @pytest.mark.parametrize('arg', ['-d', '--metadata'])
@@ -461,7 +461,7 @@ msgstr ""
 
     assert exitcode == 0
     assert striplastline(out) == expected_output
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
 
 
 @pytest.mark.parametrize('arg', ('-m', '--merge-pofiles', '--merge-po-files'))
@@ -499,7 +499,7 @@ msgstr ""
 
     assert exitcode == 0
     assert striplastline(out) == expected_output
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
 
 
 @pytest.mark.parametrize('arg', ('-r', '--remove-not-found'))
@@ -536,7 +536,7 @@ msgstr ""
 
     assert exitcode == 0
     assert striplastline(out) == expected_output
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
 
 
 @pytest.mark.parametrize('arg', ('-x', '--extension', '--ext'))
@@ -602,7 +602,7 @@ def test_extensions(
 
     assert exitcode == 0
     assert striplastline(out) == expected_output
-    assert pofile.__unicode__() == expected_output
+    assert str(pofile) == expected_output
 
 
 @pytest.mark.parametrize(
@@ -617,7 +617,7 @@ def test_md2po_cli_running_osenv(striplastline, value, capsys):
     out, err = capsys.readouterr()
 
     assert exitcode == 0
-    assert pofile.__unicode__() == EXAMPLE['output']
+    assert str(pofile) == EXAMPLE['output']
     assert striplastline(out) == EXAMPLE['output']
     assert os.environ.get('_MDPO_RUNNING') == value
 

--- a/test/test_md2po/test_md2po_cli.py
+++ b/test/test_md2po/test_md2po_cli.py
@@ -34,7 +34,7 @@ def test_stdin(capsys, monkeypatch):
     pofile, exitcode = run()
     out, err = capsys.readouterr()
     assert exitcode == 0
-    assert str(f'{pofile}\n') == EXAMPLE['output']
+    assert f'{pofile}\n' == EXAMPLE['output']
     assert out == EXAMPLE['output']
 
 
@@ -82,7 +82,7 @@ def test_quiet(capsys, arg):
     out, err = capsys.readouterr()
 
     assert exitcode == 0
-    assert str(f'{pofile}\n') == EXAMPLE['output']
+    assert f'{pofile}\n' == EXAMPLE['output']
     assert out == ''
 
 
@@ -92,7 +92,7 @@ def test_debug(capsys, arg):
     out, err = capsys.readouterr()
 
     assert exitcode == 0
-    assert str(f'{pofile}\n') == EXAMPLE['output']
+    assert f'{pofile}\n' == EXAMPLE['output']
 
     po_output_checked = False
 
@@ -223,7 +223,7 @@ def test_mo_filepath(capsys, arg):
         pofile, exitcode = run([EXAMPLE['input'], arg, mo_file.name])
         out, err = capsys.readouterr()
         assert exitcode == 0
-        assert str(f'{pofile}\n') == EXAMPLE['output']
+        assert f'{pofile}\n' == EXAMPLE['output']
         assert out == EXAMPLE['output']
         assert os.path.exists(mo_file.name)
 

--- a/test/test_md2po/test_md2po_events.py
+++ b/test/test_md2po/test_md2po_events.py
@@ -64,7 +64,7 @@ def test_enter_leave_span_event(abort_event, expected_msgid):
 
     content = 'Hello `with` codespan'
 
-    po = markdown_to_pofile(
+    pofile = markdown_to_pofile(
         content,
         events={
             'enter_span': lambda *_: not abort_event,
@@ -72,7 +72,7 @@ def test_enter_leave_span_event(abort_event, expected_msgid):
         },
     )
 
-    assert str(po).splitlines()[4].split('"')[1] == expected_msgid
+    assert str(pofile).splitlines()[4].split('"')[1] == expected_msgid
 
 
 @pytest.mark.parametrize(('abort_event'), (True, False))

--- a/test/test_md2po/test_md2po_events.py
+++ b/test/test_md2po/test_md2po_events.py
@@ -61,7 +61,6 @@ def test_enter_block_event(abort_event):
     ),
 )
 def test_enter_leave_span_event(abort_event, expected_msgid):
-
     content = 'Hello `with` codespan'
 
     pofile = markdown_to_pofile(
@@ -101,6 +100,8 @@ def test_command_event(abort_event):
         comment,
         original_command,
     ):
+        # here 'normalize_mdpo_command' is added to simulate a real behaviour,
+        # is not related with the test itself
         if normalize_mdpo_command(command) is None and abort_event:
             raise ValueError('unhandled command for testing')
 
@@ -119,6 +120,62 @@ def test_command_event(abort_event):
         assert str(exc.value) == 'unhandled command for testing'
     else:
         md2po.extract()
+
+
+def test_command_event_return_false():
+    def skip_counter_command_event(
+        self,
+        command,
+        comment,
+        original_command,
+    ):
+        if command == 'mdpo-skip':
+            self.skip_counter += 1
+            return False
+        elif command == 'mdpo-disable-next-line':
+            return False
+
+    content = '''<!-- mdpo-skip -->
+
+some text
+
+mdpo-skip
+
+<!-- mdpo-othercommand -->
+<!-- mdpo-skip -->
+
+<!-- mdpo-disable-next-line -->
+This must be included in output
+'''
+
+    # Md2Po must be subclassed because is defined with fixed slots
+    class CustomMd2Po(Md2Po):
+        def __init__(self, *args, **kwargs):
+            self.skip_counter = 0
+            super().__init__(*args, **kwargs)
+
+    md2po = CustomMd2Po(
+        content,
+        events={
+            'command': skip_counter_command_event,
+        },
+    )
+    output = md2po.extract()
+
+    assert md2po.skip_counter == content.count('<!-- mdpo-skip -->')
+    assert output == '''#
+msgid ""
+msgstr ""
+
+msgid "some text"
+msgstr ""
+
+msgid "mdpo-skip"
+msgstr ""
+
+msgid "This must be included in output"
+msgstr ""
+'''
 
 
 def test_msgid_event():

--- a/test/test_md2po/test_obsoletes.py
+++ b/test/test_md2po/test_obsoletes.py
@@ -47,12 +47,14 @@ def test_obsolete_not_equal_found(
     pofile_content = '#\nmsgid ""\nmsgstr ""\n\nmsgid "Bar"\nmsgstr ""\n'
 
     with tmp_file(pofile_content, '.po') as po_filepath:
-        output = markdown_to_pofile(
-            markdown_content,
-            po_filepath=po_filepath,
-            mark_not_found_as_obsolete=mark_not_found_as_obsolete,
-            location=False,
-        ).__unicode__()
+        output = str(
+            markdown_to_pofile(
+                markdown_content,
+                po_filepath=po_filepath,
+                mark_not_found_as_obsolete=mark_not_found_as_obsolete,
+                location=False,
+            ),
+        )
     assert output == expected_output
 
 
@@ -75,11 +77,13 @@ msgstr ""
 msgid "Hello"
 msgstr "Hola"
 '''
-        output = markdown_to_pofile(
-            markdown_content,
-            po_filepath=po_filepath,
-            msgstr=default_msgstr,
-        ).__unicode__()
+        output = str(
+            markdown_to_pofile(
+                markdown_content,
+                po_filepath=po_filepath,
+                msgstr=default_msgstr,
+            ),
+        )
     assert output == expected_output
 
 
@@ -106,11 +110,13 @@ msgid "Hello"
 msgstr "Hola"
 '''
 
-        output = markdown_to_pofile(
-            markdown_content,
-            po_filepath=po_filepath,
-            msgstr=default_msgstr,
-        ).__unicode__()
+        output = str(
+            markdown_to_pofile(
+                markdown_content,
+                po_filepath=po_filepath,
+                msgstr=default_msgstr,
+            ),
+        )
     assert output == expected_output
 
 
@@ -140,9 +146,13 @@ msgid "Hello"
 msgstr "Hola"
 '''
 
-        output = markdown_to_pofile(
-            markdown_content, po_filepath=po_filepath, msgstr=default_msgstr,
-        ).__unicode__()
+        output = str(
+            markdown_to_pofile(
+                markdown_content,
+                po_filepath=po_filepath,
+                msgstr=default_msgstr,
+            ),
+        )
     assert output == expected_output
 
 
@@ -175,9 +185,13 @@ msgid "Hello"
 msgstr "Hola"
 '''
 
-        output = markdown_to_pofile(
-            markdown_content, po_filepath=po_filepath, msgstr=default_msgstr,
-        ).__unicode__()
+        output = str(
+            markdown_to_pofile(
+                markdown_content,
+                po_filepath=po_filepath,
+                msgstr=default_msgstr,
+            ),
+        )
     assert output == expected_output
 
 
@@ -202,10 +216,12 @@ msgid "Hello"
 msgstr "Hola"
 '''
 
-        output = markdown_to_pofile(
-            markdown_content,
-            po_filepath=po_filepath,
-        ).__unicode__()
+        output = str(
+            markdown_to_pofile(
+                markdown_content,
+                po_filepath=po_filepath,
+            ),
+        )
     assert output == expected_output
 
 
@@ -235,7 +251,10 @@ msgstr ""
 #~ msgstr "Hola"
 '''
 
-        output = markdown_to_pofile(
-            markdown_content, po_filepath=po_filepath,
-        ).__unicode__()
+        output = str(
+            markdown_to_pofile(
+                markdown_content,
+                po_filepath=po_filepath,
+            ),
+        )
     assert output == expected_output

--- a/test/test_md2po/test_x_headers.py
+++ b/test/test_md2po/test_x_headers.py
@@ -6,13 +6,13 @@ def test_x_headers_included():
     markdown_content = '# Foo\n'
 
     extensions = DEFAULT_MD4C_GENERIC_PARSER_EXTENSIONS + ['underline']
-    po = markdown_to_pofile(
+    pofile = markdown_to_pofile(
         markdown_content,
         xheaders=True,
         plaintext=False,
         extensions=extensions,
     )
-    assert po.__unicode__() == '''#
+    assert str(pofile) == '''#
 msgid ""
 msgstr ""
 "x-mdpo-bold-end: **\\n"

--- a/test/test_md2po/test_x_headers.py
+++ b/test/test_md2po/test_x_headers.py
@@ -12,7 +12,7 @@ def test_x_headers_included():
         plaintext=False,
         extensions=extensions,
     )
-    assert str(pofile) == '''#
+    assert pofile == '''#
 msgid ""
 msgstr ""
 "x-mdpo-bold-end: **\\n"

--- a/test/test_mdpo2html/test_mdpo2html_cli.py
+++ b/test/test_mdpo2html/test_mdpo2html_cli.py
@@ -26,28 +26,30 @@ msgstr "Algo de texto aquí"
 
 def test_stdin(capsys, monkeypatch, tmp_file):
     monkeypatch.setattr('sys.stdin', io.StringIO(EXAMPLE['html-input']))
-    with tmp_file(EXAMPLE['pofile'], '.po') as po_filepath:
 
+    with tmp_file(EXAMPLE['pofile'], '.po') as po_filepath:
         output, exitcode = run(['-p', po_filepath])
-        out, err = capsys.readouterr()
+        stdout, stderr = capsys.readouterr()
 
         assert exitcode == 0
         assert output == EXAMPLE['html-output'][:-1]  # rstrip("\n")
-        assert out == EXAMPLE['html-output']
+        assert stdout == EXAMPLE['html-output']
+        assert stderr == ''
 
 
 @pytest.mark.parametrize('arg', ['-q', '--quiet'])
 def test_quiet(capsys, arg, tmp_file):
     with tmp_file(EXAMPLE['pofile'], '.po') as po_filepath:
-
         output, exitcode = run([
             EXAMPLE['html-input'],
             '-p', po_filepath, arg,
         ])
-        out, err = capsys.readouterr()
+        stdout, stderr = capsys.readouterr()
 
         assert exitcode == 0
         assert output == EXAMPLE['html-output']
+        assert stdout == ''
+        assert stderr == ''
 
 
 @pytest.mark.parametrize('arg', ['-s', '--save'])
@@ -60,11 +62,11 @@ def test_save(capsys, arg, tmp_file):
             html_input_filepath, '-p', po_filepath,
             arg, html_output_filepath,
         ])
-        out, err = capsys.readouterr()
+        stdout, _ = capsys.readouterr()
 
         assert exitcode == 0
         assert output == EXAMPLE['html-output']
-        assert out == ''
+        assert stdout == ''
 
         with open(html_output_filepath) as f:
             output_html_content = f.read()
@@ -113,8 +115,8 @@ def test_ignore_files_by_filepath(capsys, arg, tmp_file):
                 arg,
                 pofiles_paths[2],
             ])
-            out, err = capsys.readouterr()
+            stdout, _ = capsys.readouterr()
 
     assert exitcode == 0
     assert f'{output}\n' == expected_output
-    assert out == expected_output
+    assert stdout == expected_output

--- a/test/test_mdpo2html/test_mdpo2html_cli.py
+++ b/test/test_mdpo2html/test_mdpo2html_cli.py
@@ -73,7 +73,7 @@ def test_save(capsys, arg, tmp_file):
 
 
 @pytest.mark.parametrize('arg', ['-i', '--ignore'])
-def test_ignore_files_by_filepath(striplastline, capsys, arg, tmp_file):
+def test_ignore_files_by_filepath(capsys, arg, tmp_file):
     pofiles_contents = [
         (
             '#\nmsgid ""\nmsgstr ""\n\nmsgid "Included"\n'
@@ -91,7 +91,7 @@ def test_ignore_files_by_filepath(striplastline, capsys, arg, tmp_file):
 
     html_input = '<p>Included</p>\n\n<p>Excluded</p>\n\n<p>Excluded 2</p>\n\n'
     expected_output = (
-        '<p>Incluida</p>\n\n<p>Excluded</p>\n\n<p>Excluded 2</p>\n\n'
+        '<p>Incluida</p>\n\n<p>Excluded</p>\n\n<p>Excluded 2</p>\n\n\n'
     )
 
     with tempfile.TemporaryDirectory() as filesdir:
@@ -116,5 +116,5 @@ def test_ignore_files_by_filepath(striplastline, capsys, arg, tmp_file):
             out, err = capsys.readouterr()
 
     assert exitcode == 0
-    assert output == expected_output
-    assert striplastline(out) == expected_output
+    assert f'{output}\n' == expected_output
+    assert out == expected_output

--- a/test/test_mdpo2html/test_mdpo2html_cli.py
+++ b/test/test_mdpo2html/test_mdpo2html_cli.py
@@ -74,27 +74,18 @@ def test_save(capsys, arg, tmp_file):
 
 @pytest.mark.parametrize('arg', ['-i', '--ignore'])
 def test_ignore_files_by_filepath(striplastline, capsys, arg, tmp_file):
-    pofiles = [
+    pofiles_contents = [
         (
-            uuid4().hex + '.po',
-            (
-                '#\nmsgid ""\nmsgstr ""\n\nmsgid "Included"\n'
-                'msgstr "Incluida"\n\n'
-            ),
+            '#\nmsgid ""\nmsgstr ""\n\nmsgid "Included"\n'
+            'msgstr "Incluida"\n\n'
         ),
         (
-            uuid4().hex + '.po',
-            (
-                '#\nmsgid ""\nmsgstr ""\n\nmsgid "Exluded"\n'
-                'msgstr "Excluida"\n\n'
-            ),
+            '#\nmsgid ""\nmsgstr ""\n\nmsgid "Exluded"\n'
+            'msgstr "Excluida"\n\n'
         ),
         (
-            uuid4().hex + '.po',
-            (
-                '#\nmsgid ""\nmsgstr ""\n\nmsgid "Exluded 2"\n'
-                'msgstr "Excluida 2"\n\n'
-            ),
+            '#\nmsgid ""\nmsgstr ""\n\nmsgid "Exluded 2"\n'
+            'msgstr "Excluida 2"\n\n'
         ),
     ]
 
@@ -104,18 +95,23 @@ def test_ignore_files_by_filepath(striplastline, capsys, arg, tmp_file):
     )
 
     with tempfile.TemporaryDirectory() as filesdir:
-        for pofile in pofiles:
-            with open(os.path.join(filesdir, pofile[0]), 'w') as f:
-                f.write(pofile[1])
+        pofiles_paths = [
+            os.path.join(filesdir, f'{uuid4().hex}.po')
+            for _ in range(len(pofiles_contents))
+        ]
+        pofiles_paths_contents = zip(pofiles_paths, pofiles_contents)
+        for pofile_path, pofile_content in pofiles_paths_contents:
+            with open(pofile_path, 'w') as f:
+                f.write(pofile_content)
         with tmp_file(html_input, '.html') as html_input_filepath:
             output, exitcode = run([
                 html_input_filepath,
                 '-p',
                 os.path.join(filesdir, '*.po'),
                 arg,
-                pofiles[1][0],
+                pofiles_paths[1],
                 arg,
-                pofiles[2][0],
+                pofiles_paths[2],
             ])
             out, err = capsys.readouterr()
 

--- a/test/test_po2md/test_po2md_cli.py
+++ b/test/test_po2md/test_po2md_cli.py
@@ -30,13 +30,12 @@ msgstr "Algo de texto aquí"
 def test_stdin(capsys, monkeypatch, tmp_file):
     monkeypatch.setattr('sys.stdin', io.StringIO(EXAMPLE['markdown-input']))
     with tmp_file(EXAMPLE['pofile'], '.po') as po_filepath:
-
         output, exitcode = run(['-p', po_filepath])
-        out, err = capsys.readouterr()
+        stdout, _ = capsys.readouterr()
 
         assert exitcode == 0
         assert f'{output}\n' == EXAMPLE['markdown-output']
-        assert out == EXAMPLE['markdown-output']
+        assert stdout == EXAMPLE['markdown-output']
 
 
 @pytest.mark.parametrize('arg', ['-q', '--quiet'])
@@ -47,11 +46,12 @@ def test_quiet(capsys, arg, tmp_file):
             EXAMPLE['markdown-input'],
             '-p', po_filepath, arg,
         ])
-        out, err = capsys.readouterr()
+        stdout, stderr = capsys.readouterr()
 
         assert exitcode == 0
         assert f'{output}\n' == EXAMPLE['markdown-output']
-        assert out == ''
+        assert stdout == ''
+        assert stderr == ''
 
 
 @pytest.mark.parametrize('arg', ['-D', '--debug'])
@@ -60,14 +60,13 @@ def test_debug(capsys, arg, tmp_file):
             tmp_file(EXAMPLE['markdown-input'], '.md') as input_md_filepath:
 
         output, exitcode = run([input_md_filepath, '-p', po_filepath, arg])
-        out, err = capsys.readouterr()
 
         assert exitcode == 0
         assert f'{output}\n' == EXAMPLE['markdown-output']
 
         md_output_checked = False
-
-        outlines = out.splitlines()
+        stdout, _ = capsys.readouterr()
+        outlines = stdout.splitlines()
         for i, line in enumerate(outlines):
             assert re.match(
                 (
@@ -97,11 +96,11 @@ def test_save(capsys, arg, tmp_file):
             input_md_filepath, '-p', po_filepath,
             arg, output_md_filepath,
         ])
-        out, err = capsys.readouterr()
+        stdout, _ = capsys.readouterr()
 
         assert exitcode == 0
         assert f'{output}\n' == EXAMPLE['markdown-output']
-        assert out == ''
+        assert stdout == ''
 
         with open(output_md_filepath) as f:
             assert f'{f.read()}\n' == EXAMPLE['markdown-output']
@@ -145,15 +144,17 @@ def test_ignore_files_by_filepath(capsys, arg):
             f.write('Included\n\nExcluded\n\nExcluded 2\n')
 
         output, exitcode = run([
-            input_md_filepath, '-p',
+            input_md_filepath,
+            '-p',
             os.path.join(filesdir, '*.po'),
             arg,
             os.path.join(filesdir, pofiles[1][0]),
             arg,
             os.path.join(filesdir, pofiles[2][0]),
         ])
-        out, err = capsys.readouterr()
+
+    stdout, _ = capsys.readouterr()
 
     assert exitcode == 0
     assert f'{output}\n' == expected_output
-    assert out == expected_output
+    assert stdout == expected_output

--- a/test/test_po2md/test_po2md_translate.py
+++ b/test/test_po2md/test_po2md_translate.py
@@ -42,11 +42,9 @@ def test_translate_save(filename):
         os.path.splitext(os.path.basename(filepath_in))[0] + '.po',
     )
 
-    save_file = tempfile.NamedTemporaryFile(suffix='.po')
+    with tempfile.NamedTemporaryFile(suffix='.po') as save_file:
 
-    pofile_to_markdown(filepath_in, po_filepath, save=save_file.name)
-    save_file.seek(0)
+        pofile_to_markdown(filepath_in, po_filepath, save=save_file.name)
 
-    with open(filepath_out) as expect_file:
-        assert save_file.read().decode('utf-8') == expect_file.read()
-    save_file.close()
+        with open(filepath_out) as expect_file:
+            assert save_file.read().decode('utf-8') == expect_file.read()

--- a/test/test_po2md/translate-examples/code-blocks.md
+++ b/test/test_po2md/translate-examples/code-blocks.md
@@ -15,6 +15,8 @@ Fenced code block with tildes
 ~~~
 
     Indented code block
+    
+    After empty line
 
 !!! note
 

--- a/test/test_po2md/translate-examples/code-blocks.md.expect.md
+++ b/test/test_po2md/translate-examples/code-blocks.md.expect.md
@@ -15,6 +15,8 @@ Fenced code block with tildes
 ~~~
 
     Indented code block
+    
+    After empty line
 
 !!! note
 

--- a/test/test_po2md/translate-examples/images.md
+++ b/test/test_po2md/translate-examples/images.md
@@ -6,6 +6,12 @@
 
 ![Alt text][id]
 
-[id]: url/to/image  "Optional title attribute"
+[id]: url/to/image "Optional title attribute"
 
 My ![foo bar](/path/to/train.jpg "title")
+
+[![Image inside inline link](https://image.ext)](https://link.ext)
+
+[![Image inside referenced link](https://image.ext)][1]
+
+[1]: https://link-1.ext

--- a/test/test_po2md/translate-examples/images.md.expect.md
+++ b/test/test_po2md/translate-examples/images.md.expect.md
@@ -7,3 +7,10 @@
 ![Texto alternativo](url/to/imagen "Atributo título opcional")
 
 Mi ![foo bar](/path/to/tren.jpg "título")
+
+[![Imagen dentro de link en línea](https://image.ext)](https://enlace.ext)
+
+[![Imagen dentro de link referenciado](https://imagen.ext)][1]
+
+[id]: url/a/imagen "Título de atributo opcional"
+[1]: https://enlace-1.ext

--- a/test/test_po2md/translate-examples/images.po
+++ b/test/test_po2md/translate-examples/images.po
@@ -16,3 +16,15 @@ msgstr "![Texto alternativo](url/to/imagen \"Atributo título opcional\")"
 
 msgid "My ![foo bar](/path/to/train.jpg \"title\")"
 msgstr "Mi ![foo bar](/path/to/tren.jpg \"título\")"
+
+msgid "[![Image inside inline link](https://image.ext)](https://link.ext)"
+msgstr "[![Imagen dentro de link en línea](https://image.ext)](https://enlace.ext)"
+
+msgid "[![Image inside referenced link](https://image.ext)][1]"
+msgstr "[![Imagen dentro de link referenciado](https://imagen.ext)][1]"
+
+msgid "[id]: url/to/image \"Optional title attribute\""
+msgstr "[id]: url/a/imagen \"Título de atributo opcional\""
+
+msgid "[1]: https://link-1.ext"
+msgstr "[1]: https://enlace-1.ext"

--- a/test/test_text.py
+++ b/test/test_text.py
@@ -69,6 +69,10 @@ def test_parse_escaped_pair(
     (
         ('1', 1, None),
         ('1.1', 1, None),
+        (-1, math.inf, None),
+        (-1.1, math.inf, None),
+        ('-1', math.inf, None),
+        ('-1.1', math.inf, None),
         (0, math.inf, None),
         (-0, math.inf, None),
         ('a', None, ValueError),

--- a/test/test_text.py
+++ b/test/test_text.py
@@ -1,8 +1,16 @@
 """Tests for mdpo text utilities."""
 
+import math
+
 import pytest
 
-from mdpo.text import min_not_max_chars_in_a_row, parse_escaped_pair
+from mdpo.text import (
+    min_not_max_chars_in_a_row,
+    parse_escaped_pair,
+    parse_strint_0_inf,
+    removeprefix,
+    removesuffix,
+)
 
 
 @pytest.mark.parametrize(
@@ -54,3 +62,45 @@ def test_parse_escaped_pair(
         key, value = parse_escaped_pair(text)
         assert key == expected_key
         assert value == expected_value
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected_value', 'expected_error'),
+    (
+        ('1', 1, None),
+        ('1.1', 1, None),
+        (0, math.inf, None),
+        (-0, math.inf, None),
+        ('a', None, ValueError),
+        ('inf', math.inf, None),
+        ('-inf', math.inf, None),
+    ),
+)
+def test_parse_strint_0_inf(value, expected_value, expected_error):
+    if expected_error:
+        with pytest.raises(expected_error):
+            parse_strint_0_inf(value)
+    else:
+        assert parse_strint_0_inf(value) == expected_value
+
+
+@pytest.mark.parametrize(
+    ('value', 'prefix', 'expected_value'),
+    (
+        ('foo', 'fo', 'o'),
+        ('bar', 'fo', 'bar'),
+    ),
+)
+def test_removeprefix(value, prefix, expected_value):
+    assert removeprefix(value, prefix) == expected_value
+
+
+@pytest.mark.parametrize(
+    ('value', 'suffix', 'expected_value'),
+    (
+        ('foo', 'oo', 'f'),
+        ('bar', 'fo', 'bar'),
+    ),
+)
+def test_removesuffix(value, suffix, expected_value):
+    assert removesuffix(value, suffix) == expected_value


### PR DESCRIPTION
- Use f-strings for string formatting.
- Replace `pofile.__unicode__()` with `str(pofile)`.
- Always use `pofile` instead of `po` as variable name for `polib.POFile` object instances.
- Get rid of `striplastline` tests fixture.
- Get rid of `filehash` and `save_pofile_checking_file_changed` utility functions.
- Rewrite `tempfile.NamedTemporaryFile` in tests using context managers.
- Add more tests.
- Performance improvement for `text.parse_strint_0_inf` function.
- `wrapwidth` arguments now accept floats and negative numbers.
- Fix indented code block empty line error in `po2md`.
- Fix image links regression from [v0.3.68](https://github.com/mondeja/mdpo/releases/tag/v0.3.68) (closes #174).