### PR TITLE
Drop uneeded `__slots__` from `md2po` and `po2md` class implementations

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.77
+current_version = 0.3.78
 
 [bumpversion:file:mdpo/__init__.py]
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -43,8 +43,8 @@ po2md
 markdownlint compatible configuration
 *************************************
 
-The output produced by :ref:`cli:po2md` is compatible with the
- following `Markdownlint configuration`_:
+The output produced by :ref:`cli:po2md` is compatible with the following
+`Markdownlint configuration`_:
 
 .. code-block:: json
 

--- a/docs/pre-commit-hooks.rst
+++ b/docs/pre-commit-hooks.rst
@@ -19,7 +19,7 @@ so you don't need to specify them.
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v0.3.77
+           rev: v0.3.78
            hooks:
              - id: md2po
                args:
@@ -32,7 +32,7 @@ so you don't need to specify them.
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v0.3.77
+           rev: v0.3.78
            hooks:
              - id: md2po
                files: ^README\.md
@@ -53,7 +53,7 @@ po2md
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v0.3.77
+           rev: v0.3.78
            hooks:
              - id: po2md
                args:
@@ -68,7 +68,7 @@ po2md
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v0.3.77
+           rev: v0.3.78
            hooks:
              - id: po2md
                files: ^README\.md
@@ -91,7 +91,7 @@ md2po2md
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v0.3.77
+           rev: v0.3.78
            hooks:
              - id: md2po2md
                args:
@@ -108,7 +108,7 @@ md2po2md
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v0.3.77
+           rev: v0.3.78
            hooks:
              - id: md2po2md
                files: ^README\.md
@@ -133,7 +133,7 @@ mdpo2html
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v0.3.77
+           rev: v0.3.78
            hooks:
              - id: mdpo2html
                args:
@@ -148,7 +148,7 @@ mdpo2html
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v0.3.77
+           rev: v0.3.78
            hooks:
              - id: mdpo2html
                files: ^README\.html

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -12,7 +12,7 @@ tutorial are covered the most common workflows.
 Markdown to markdown
 ====================
 
-If you want to translate a Markdown source using PO file and produce
+If you want to translate a Markdown source using a PO file and produce
 translated Markdown output, use this method.
 
 Given next directory tree:

--- a/mdpo/__init__.py
+++ b/mdpo/__init__.py
@@ -2,7 +2,7 @@
 
 __description__ = ('Markdown files translation using PO files.')
 __title__ = 'mdpo'
-__version__ = '0.3.77'
+__version__ = '0.3.78'
 __all__ = [
     '__description__',
     '__title__',

--- a/mdpo/md2po/__init__.py
+++ b/mdpo/md2po/__init__.py
@@ -80,8 +80,6 @@ class Md2Po:
         'code_start_string_escaped',
         'code_end_string',
         'code_end_string_escaped',
-        'link_start_string',
-        'link_end_string',
         'strikethrough_start_string',
         'strikethrough_end_string',
         'latexmath_start_string',

--- a/mdpo/po2md/__init__.py
+++ b/mdpo/po2md/__init__.py
@@ -53,8 +53,6 @@ class Po2Md:
         'code_start_string_escaped',
         'code_end_string',
         'code_end_string_escaped',
-        'link_start_string',
-        'link_end_string',
         'wikilink_start_string',
         'wikilink_end_string',
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mdpo
-version = 0.3.77
+version = 0.3.78
 description = Markdown files translation using PO files.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -135,7 +135,7 @@ sections = STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER
 
 [build_sphinx]
 project = mdpo
-version = 0.3.77
+version = 0.3.78
 release = 0.3.74
 source-dir = docs
 build-dir = docs/_build

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,10 +2,14 @@ import ast
 import inspect
 import os
 import subprocess
+import sys
 import tempfile
 from contextlib import contextmanager
 
 import pytest
+
+
+AST_ELTS_VALUE_ATTR = 's' if sys.version_info < (3, 8) else 'value'
 
 
 @contextmanager
@@ -56,7 +60,8 @@ def class_slots():
                     and node.body[0].targets[0].id == '__slots__'
                 ):
                     self.slots.extend([
-                        elt.value for elt in node.body[0].value.elts
+                        getattr(elt, AST_ELTS_VALUE_ATTR)
+                        for elt in node.body[0].value.elts
                     ])
 
         modtree = ast.parse(inspect.getsource(code))

--- a/test/test_md2po/test_extractor.py
+++ b/test/test_md2po/test_extractor.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -108,3 +109,17 @@ def test_md2po_save_without_po_filepath():
     )
     with pytest.raises(ValueError, match=expected_msg):
         md2po.extract(save=True)
+
+
+def test___slots__(class_slots):
+    slots = class_slots(Md2Po)
+    assert slots
+
+    md2po_implementation_filepath = os.path.join(
+        'mdpo', 'md2po', '__init__.py',
+    )
+    with open(md2po_implementation_filepath) as f:
+        content = f.read()
+
+    for slot in slots:
+        assert f'self.{slot}' in content

--- a/test/test_po2md/test_po2md_translator.py
+++ b/test/test_po2md/test_po2md_translator.py
@@ -1,0 +1,17 @@
+import os
+
+from mdpo.po2md import Po2Md
+
+
+def test___slots__(class_slots):
+    slots = class_slots(Po2Md)
+    assert slots
+
+    po2md_implementation_filepath = os.path.join(
+        'mdpo', 'po2md', '__init__.py',
+    )
+    with open(po2md_implementation_filepath) as f:
+        content = f.read()
+
+    for slot in slots:
+        assert f'self.{slot}' in content


### PR DESCRIPTION
Drop uneeded `__slots__` values from `md2po` and `po2md` classes.