### PR TITLE
Refactor usage of `pytest.raises` in parametric tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
           - '3.10'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python v${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -49,14 +49,14 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python v3.8
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        name: Install Python v3.x
         with:
-          python-version: 3.8
+          python-version: 3.x
       - name: Build sdist
         run: python setup.py sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -66,16 +66,16 @@ jobs:
     name: Build wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python v3.8
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        name: Install Python v3.x
         with:
-          python-version: 3.8
+          python-version: 3.x
       - name: Install wheel
         run: python -m pip install --upgrade wheel
       - name: Build wheel
         run: python setup.py bdist_wheel
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./dist/*.whl
 
@@ -86,7 +86,7 @@ jobs:
       - build-wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
@@ -104,7 +104,7 @@ jobs:
       - build-wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get tag metadata
         id: tag
         run: |
@@ -129,12 +129,12 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         name: Download builds
         with:
           name: artifact
           path: dist
-      - uses: shogo82148/actions-upload-release-asset@v1.3.0
+      - uses: shogo82148/actions-upload-release-asset@v1
         name: Upload release assets
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ dev =
     pre-commit==2.15.0
     pytest==6.2.4
     pytest-cov==2.12.1
-    pytest-maybe-raises==0.1.0
+    pytest-maybe-raises==0.1.1
     sphinx-argparse-cli==1.8.3
     sphinx-github-changelog==1.2.0
     sphinx-rtd-theme==1.0.0
@@ -95,7 +95,7 @@ test =
     pre-commit==2.15.0
     pytest==6.2.4
     pytest-cov==2.12.1
-    pytest-maybe-raises==0.1.0
+    pytest-maybe-raises==0.1.1
 
 [coverage:report]
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ dev =
     pre-commit==2.15.0
     pytest==6.2.4
     pytest-cov==2.12.1
+    pytest-maybe-raises==0.1.0
     sphinx-argparse-cli==1.8.3
     sphinx-github-changelog==1.2.0
     sphinx-rtd-theme==1.0.0
@@ -94,6 +95,7 @@ test =
     pre-commit==2.15.0
     pytest==6.2.4
     pytest-cov==2.12.1
+    pytest-maybe-raises==0.1.0
 
 [coverage:report]
 exclude_lines =

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -103,6 +103,20 @@ def git_add_commit():
     return _git_add_commit
 
 
+@contextlib.contextmanager
+def _maybe_raises(maybe_exception_class, **kwargs):
+    if hasattr(maybe_exception_class, '__traceback__'):
+        with pytest.raises(maybe_exception_class, **kwargs):
+            yield
+    else:
+        yield
+
+
+@pytest.fixture()
+def maybe_raises():
+    return _maybe_raises
+
+
 def get_class_slots(code):
     class ClassSlotsExtractor(ast.NodeVisitor):
         ast_elts_value_attr = (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -103,20 +103,6 @@ def git_add_commit():
     return _git_add_commit
 
 
-@contextlib.contextmanager
-def _maybe_raises(maybe_exception_class, **kwargs):
-    if hasattr(maybe_exception_class, '__traceback__'):
-        with pytest.raises(maybe_exception_class, **kwargs):
-            yield
-    else:
-        yield
-
-
-@pytest.fixture()
-def maybe_raises():
-    return _maybe_raises
-
-
 def get_class_slots(code):
     class ClassSlotsExtractor(ast.NodeVisitor):
         ast_elts_value_attr = (

--- a/test/test_unit/test_cli.py
+++ b/test/test_unit/test_cli.py
@@ -4,23 +4,20 @@ from mdpo.cli import parse_command_aliases_cli_arguments
 
 
 @pytest.mark.parametrize(
-    ('command_aliases', 'expected_response', 'expected_stderr'),
+    ('command_aliases', 'expected_result'),
     (
         pytest.param(
             ['foo:bar'],
             {'foo': 'bar'},
-            None,
             id='foo:bar-{"foo": "bar"}',
         ),
         pytest.param(
             ['foo:bar', r'baz\\::qux'],
             {'foo': 'bar', 'baz:': 'qux'},
-            None,
             id=r'foo:bar,baz\\::qux-{"foo": "bar", "baz:": "qux"}',
         ),
         pytest.param(
             ['foobar'],
-            None,
             (
                 "The value 'foobar' passed to argument --command-alias"
                 " can't be parsed. Please, separate the pair"
@@ -30,7 +27,6 @@ from mdpo.cli import parse_command_aliases_cli_arguments
         ),
         pytest.param(
             ['foo:bar', 'foo:baz'],
-            None,
             (
                 "Multiple resolutions for 'foo' alias passed to"
                 ' --command-alias arguments.\n'
@@ -41,17 +37,17 @@ from mdpo.cli import parse_command_aliases_cli_arguments
 )
 def test_parse_command_aliases_cli_arguments(
     command_aliases,
-    expected_response,
-    expected_stderr,
+    expected_result,
     capsys,
 ):
-    if expected_stderr:
+
+    if isinstance(expected_result, str):  # stderr expected
         with pytest.raises(SystemExit):
             parse_command_aliases_cli_arguments(command_aliases)
         stdout, stderr = capsys.readouterr()
-        assert stderr == expected_stderr
+        assert stderr == expected_result
         assert stdout == ''
     else:
         assert parse_command_aliases_cli_arguments(
             command_aliases,
-        ) == expected_response
+        ) == expected_result

--- a/test/test_unit/test_command.py
+++ b/test/test_unit/test_command.py
@@ -73,11 +73,10 @@ def test_normalize_mdpo_command(value, expected_command):
         ),
     ),
 )
-def test_normalize_mdpo_command_aliases(command_aliases, expected_result):
-    if hasattr(expected_result, '__traceback__'):
-        with pytest.raises(expected_result):
-            normalize_mdpo_command_aliases(command_aliases)
-    else:
+def test_normalize_mdpo_command_aliases(
+    command_aliases, expected_result, maybe_raises,
+):
+    with maybe_raises(expected_result):
         assert normalize_mdpo_command_aliases(
             command_aliases,
         ) == expected_result

--- a/test/test_unit/test_text.py
+++ b/test/test_unit/test_text.py
@@ -31,34 +31,27 @@ def test_min_not_max_chars_in_a_row(char, text, expected_result):
 
 
 @pytest.mark.parametrize(
-    ('text', 'expected_key', 'expected_value', 'expected_error'),
+    ('text', 'expected_result'),
     (
-        ('foo:bar', 'foo', 'bar', None),
-        ('foo:Bar:', 'foo', 'Bar:', None),
-        ('foo:   bar:', 'foo', 'bar:', None),
-        ('foo: \n  bar:', 'foo', 'bar:', None),
-        ('foo:Bar\\:', 'foo', 'Bar\\:', None),
-        ('\\:foo:bar', ':foo', 'bar', None),
-        (r'foo\\:Bar:baz', 'foo:Bar', 'baz', None),
-        (r'foo\\:Bar:baz\\', 'foo:Bar', r'baz\\', None),
+        ('foo:bar', ('foo', 'bar')),
+        ('foo:Bar:', ('foo', 'Bar:')),
+        ('foo:   bar:', ('foo', 'bar:')),
+        ('foo: \n  bar:', ('foo', 'bar:')),
+        ('foo:Bar\\:', ('foo', 'Bar\\:')),
+        ('\\:foo:bar', (':foo', 'bar')),
+        (r'foo\\:Bar:baz', ('foo:Bar', 'baz')),
+        (r'foo\\:Bar:baz\\', ('foo:Bar', r'baz\\')),
         # : at the beginning means escaped
-        (r':foo\\:Bar:baz\\', ':foo:Bar', r'baz\\', None),
-        ('foo', None, None, ValueError),
-        (':', None, None, ValueError),
-        ('', None, None, ValueError),
+        (r':foo\\:Bar:baz\\', (':foo:Bar', r'baz\\')),
+        ('foo', ValueError),
+        (':', ValueError),
+        ('', ValueError),
     ),
 )
-def test_parse_escaped_pair(
-    text,
-    expected_key,
-    expected_value,
-    expected_error,
-):
-    if expected_error:
-        with pytest.raises(expected_error):
-            parse_escaped_pair(text)
-    else:
+def test_parse_escaped_pair(text, expected_result, maybe_raises):
+    with maybe_raises(expected_result):
         key, value = parse_escaped_pair(text)
+        expected_key, expected_value = expected_result
         assert key == expected_key
         assert value == expected_value
 
@@ -85,11 +78,8 @@ def test_parse_escaped_pair(
         ('+1E6', 1000000),
     ),
 )
-def test_parse_strint_0_inf(value, expected_result):
-    if hasattr(expected_result, '__traceback__'):
-        with pytest.raises(expected_result):
-            parse_strint_0_inf(value)
-    else:
+def test_parse_strint_0_inf(value, expected_result, maybe_raises):
+    with maybe_raises(expected_result):
         assert parse_strint_0_inf(value) == expected_result
 
 


### PR DESCRIPTION
This is a common pattern that I use in parametric tests:

- Write expected response in a variable with a value of any type or `None`.
- Write expected error in a variable with an exception class or `None`.
- Check in the test `if hasattr(expected_result, '__traceback__') { write error test } else { write resulting test }`

This is an antipattern that I want to avoid so created a fixture. With it I can:

- Write expected response or error in the same variable.
- The test now is: `with { maybe_fails_context }(value_or_exception_class) { write response test that will not be executed if fails, just will be checked the exception raising }`

---

The advantadges are:

- Avoid multibranching in tests.
- Avoid to write more code in general, more variables in parametrization and more `if`s in the test body.

The disadvantadges are:

- I need to know and integrate how it works: if the test fails the context exists, so the code after the failure will not be executed.
- Is not explicit.