### PR TITLE
Add `flake8-encodings` plugin to flakeheaven linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
           - flake8-printf-formatting
           - flake8-pytest-style
           - flake8-bugbear
+          - flake8-encodings
           - dlint
           - pysetenv
         entry: pysetenv FLAKEHEAVEN_CACHE_TIMEOUT=0 flakeheaven lint

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,8 @@ rootdir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, rootdir)
 
 # -- Project information -----------------------------------------------------
-with open(os.path.join(rootdir, 'pyproject.toml')) as f:
+pyproject_toml_path = os.path.join(rootdir, 'pyproject.toml')
+with open(pyproject_toml_path, encoding='utf-8') as f:
     pyproject_lines = f.read().splitlines()
 
 if pyproject_lines[0] != '[tool.poetry]':
@@ -33,7 +34,8 @@ for line in pyproject_lines:
     elif not line:
         break
 
-with open(os.path.join(rootdir, 'LICENSE')) as f:
+license_path = os.path.join(rootdir, 'LICENSE')
+with open(license_path, encoding='utf-8') as f:
     license_years_range = re.search(
         r'Copyright \(c\) (\d+-\d+)', f.read(),
     ).group(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ flake8-print = ["+*"]
 flake8-printf-formatting = ["+*"]
 flake8-pytest-style = ["+*"]
 flake8-bugbear = ["+*"]
+flake8-encodings = ["+*"]
 dlint = ["+*"]
 
 [tool.flakeheaven.exceptions."*.rst"]

--- a/src/mdpo/md2po/__main__.py
+++ b/src/mdpo/md2po/__main__.py
@@ -159,7 +159,7 @@ def parse_options(args):
     if '-h' in args or '--help' in args:
         parser.print_help()
         sys.exit(1)
-    opts, unknown = parser.parse_known_args(args)
+    opts, _ = parser.parse_known_args(args)
 
     files_or_content = ''
     if not sys.stdin.isatty():
@@ -178,7 +178,7 @@ def parse_options(args):
         opts.extensions = DEFAULT_MD4C_GENERIC_PARSER_EXTENSIONS
 
     if opts.ignore_msgids is not None:
-        with open(opts.ignore_msgids) as f:
+        with open(opts.ignore_msgids, encoding=opts.po_encoding) as f:
             opts.ignore_msgids = f.read().splitlines()
     else:
         opts.ignore_msgids = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def _create_tmpdir_file(tmpdir, file_relpath, content):
     filepath = os.path.join(tmpdir, file_relpath)
     file_parent_dir = os.path.abspath(os.path.dirname(filepath))
     os.makedirs(file_parent_dir, exist_ok=True)
-    with open(filepath, 'w') as f:
+    with open(filepath, 'w', encoding='utf-8') as f:
         f.write(content)
     return filepath
 

--- a/tests/test_integration/test_pre_commit_hooks.py
+++ b/tests/test_integration/test_pre_commit_hooks.py
@@ -39,7 +39,7 @@ def test_md2po_pre_commit_hook(tmp_dir, git_init, git_add_commit):
         assert proc.stdout.decode('utf-8').splitlines()[-1].endswith('Passed')
 
         # second execution, is outdated
-        with open(readme_md_path, 'a') as f:
+        with open(readme_md_path, 'a', encoding='utf-8') as f:
             f.write('\nbar\n')
 
         git_add_commit('Second commit', cwd=filesdir)
@@ -51,7 +51,7 @@ def test_md2po_pre_commit_hook(tmp_dir, git_init, git_add_commit):
             '- files were modified by this hook'
         )
 
-        with open(readme_po_path) as f:
+        with open(readme_po_path, encoding='utf-8') as f:
             assert f.read() == '''#
 msgid ""
 msgstr ""
@@ -106,9 +106,9 @@ msgstr "Foo es"
         assert proc.stdout.decode('utf-8').splitlines()[-1].endswith('Passed')
 
         # second execution, is outdated
-        with open(readme_src_md_path, 'a') as f:
+        with open(readme_src_md_path, 'a', encoding='utf-8') as f:
             f.write('\nbar\n')
-        with open(readme_po_path, 'a') as f:
+        with open(readme_po_path, 'a', encoding='utf-8') as f:
             f.write('\nmsgid "bar"\nmsgstr "bar es"\n')
 
         git_add_commit('Second commit', cwd=filesdir)
@@ -119,7 +119,7 @@ msgstr "Foo es"
         assert proc.stdout.decode('utf-8').splitlines()[-1] == (
             '- files were modified by this hook'
         )
-        with open(readme_dst_md_path) as f:
+        with open(readme_dst_md_path, encoding='utf-8') as f:
             assert f.read() == '''# Foo es
 
 bar es
@@ -166,13 +166,13 @@ msgstr "Foo es"
         assert proc.returncode == 0
         assert proc.stdout.decode('utf-8').splitlines()[-1].endswith('Passed')
 
-        with open(readme_html_es_path) as f:
+        with open(readme_html_es_path, encoding='utf-8') as f:
             assert f.read() == '<h1>Foo es</h1>\n'
 
         # second execution, is outdated
-        with open(readme_html_path, 'a') as f:
+        with open(readme_html_path, 'a', encoding='utf-8') as f:
             f.write('\n<p>bar</p>\n')
-        with open(readme_po_path, 'a') as f:
+        with open(readme_po_path, 'a', encoding='utf-8') as f:
             f.write('\nmsgid "bar"\nmsgstr "bar es"\n')
 
         git_add_commit('Second commit', cwd=filesdir)
@@ -183,7 +183,7 @@ msgstr "Foo es"
         assert proc.stdout.decode('utf-8').splitlines()[-1] == (
             '- files were modified by this hook'
         )
-        with open(readme_html_es_path) as f:
+        with open(readme_html_es_path, encoding='utf-8') as f:
             assert f.read() == '<h1>Foo es</h1>\n\n<p>bar es</p>\n'
 
 
@@ -225,7 +225,7 @@ def test_md2po2md_pre_commit_hook(tmp_dir, git_init, git_add_commit):
         assert os.path.isfile(readme_md_es_path)
         assert os.path.isfile(readme_po_es_path)
 
-        with open(readme_po_es_path) as f:
+        with open(readme_po_es_path, encoding='utf-8') as f:
             assert f.read() == '''#
 msgid ""
 msgstr ""
@@ -234,11 +234,11 @@ msgid "Foo"
 msgstr ""
 '''
 
-        with open(readme_md_es_path) as f:
+        with open(readme_md_es_path, encoding='utf-8') as f:
             assert f.read() == '# Foo\n'
 
         # second execution, translation
-        with open(readme_po_es_path, 'w') as f:
+        with open(readme_po_es_path, 'w', encoding='utf-8') as f:
             f.write('''#
 msgid ""
 msgstr ""
@@ -255,7 +255,7 @@ msgstr "Foo es"
             '- files were modified by this hook'
         )
 
-        with open(readme_md_es_path) as f:
+        with open(readme_md_es_path, encoding='utf-8') as f:
             assert f.read() == '# Foo es\n'
 
         # third execution, is updated

--- a/tests/test_unit/test_docs.py
+++ b/tests/test_unit/test_docs.py
@@ -3,7 +3,7 @@ import os
 
 def test_devref_index():
     devref_index_path = os.path.join('docs', 'devref', 'index.rst')
-    with open(devref_index_path) as f:
+    with open(devref_index_path, encoding='utf-8') as f:
         devref_index_content = f.read()
 
     utils_index, implementations_index = [], []

--- a/tests/test_unit/test_md.py
+++ b/tests/test_unit/test_md.py
@@ -8,7 +8,7 @@ def test_MarkdownSpanWrapper___slots__(class_slots):
     assert slots
 
     md_util_filepath = os.path.join('src', 'mdpo', 'md.py')
-    with open(md_util_filepath) as f:
+    with open(md_util_filepath, encoding='utf-8') as f:
         content = f.read()
 
     for slot in slots:

--- a/tests/test_unit/test_md2po/test_extract.py
+++ b/tests/test_unit/test_md2po/test_extract.py
@@ -34,7 +34,7 @@ def test_extract_plaintext(filename):
     filepath = os.path.join(EXAMPLES['plaintext']['dirpath'], filename)
     pofile = markdown_to_pofile(filepath, plaintext=True, location=False)
 
-    with open(f'{filepath}.expect.po') as expect_file:
+    with open(f'{filepath}.expect.po', encoding='utf-8') as expect_file:
         assert str(pofile) == expect_file.read()
 
 
@@ -43,7 +43,7 @@ def test_extract_markuptext(filename):
     filepath = os.path.join(EXAMPLES['markuptext']['dirpath'], filename)
     pofile = markdown_to_pofile(filepath, plaintext=False, location=False)
 
-    with open(f'{filepath}.expect.po') as expect_file:
+    with open(f'{filepath}.expect.po', encoding='utf-8') as expect_file:
         assert str(pofile) == expect_file.read()
 
 
@@ -57,7 +57,7 @@ def test_extract_underline(filename):
         location=False,
     )
 
-    with open(f'{filepath}.expect.po') as expect_file:
+    with open(f'{filepath}.expect.po', encoding='utf-8') as expect_file:
         assert str(pofile) == expect_file.read()
 
 
@@ -78,8 +78,8 @@ def test_extract_save(filename, tmp_file):
             location=False,
         )
 
-        with open(save_filepath) as f:
+        with open(save_filepath, encoding='utf-8') as f:
             result = f.read()
 
-        with open(f'{filepath}.expect.po') as expect_file:
+        with open(f'{filepath}.expect.po', encoding='utf-8') as expect_file:
             assert result == expect_file.read()

--- a/tests/test_unit/test_md2po/test_extractor.py
+++ b/tests/test_unit/test_md2po/test_extractor.py
@@ -117,7 +117,7 @@ def test___slots__(class_slots):
     md2po_implementation_filepath = os.path.join(
         'src', 'mdpo', 'md2po', '__init__.py',
     )
-    with open(md2po_implementation_filepath) as f:
+    with open(md2po_implementation_filepath, encoding='utf-8') as f:
         content = f.read()
 
     for slot in slots:

--- a/tests/test_unit/test_md2po/test_md2po_cli.py
+++ b/tests/test_unit/test_md2po/test_md2po_cli.py
@@ -230,7 +230,7 @@ msgstr ""
             '--no-location',
         ])
 
-        with open(pofile_path) as f:
+        with open(pofile_path, encoding='utf-8') as f:
             assert f'{f.read()}\n' == expected_output
 
     stdout, _ = capsys.readouterr()
@@ -257,7 +257,7 @@ msgid "Bar"
 msgstr ""
 
 '''
-    with open(pofile_path) as f:
+    with open(pofile_path, encoding='utf-8') as f:
         assert f'{f.read()}\n' == expected_output
 
     stdout, _ = capsys.readouterr()

--- a/tests/test_unit/test_md2po2md/test_md2po2md_cli.py
+++ b/tests/test_unit/test_md2po2md/test_md2po2md_cli.py
@@ -188,5 +188,5 @@ def test_md2po2md_arguments(
             # Check expected content
             for relpath, content in expected_result.items():
                 filepath = os.path.join(filesdir, relpath)
-                with open(filepath) as f:
+                with open(filepath, encoding='utf-8') as f:
                     assert f.read() == content

--- a/tests/test_unit/test_mdpo2html/test_mdpo2html_cli.py
+++ b/tests/test_unit/test_mdpo2html/test_mdpo2html_cli.py
@@ -66,7 +66,7 @@ def test_save(capsys, arg, tmp_file):
         assert output == EXAMPLE['html-output']
         assert stdout == ''
 
-        with open(html_output_filepath) as f:
+        with open(html_output_filepath, encoding='utf-8') as f:
             output_html_content = f.read()
 
         assert output_html_content == EXAMPLE['html-output']

--- a/tests/test_unit/test_mdpo2html/test_mdpo2html_translate.py
+++ b/tests/test_unit/test_mdpo2html/test_mdpo2html_translate.py
@@ -43,7 +43,7 @@ def test_translate_markuptext(filename):
 
     output = markdown_pofile_to_html(filepath_in, po_filepath)
 
-    with open(filepath_out) as f:
+    with open(filepath_out, encoding='utf-8') as f:
         expected_output = f.read()
 
     assert output == expected_output
@@ -70,7 +70,7 @@ def test_translate_merge_adjacent_markups(filename):
         merge_adjacent_markups=True,
     )
 
-    with open(filepath_out) as f:
+    with open(filepath_out, encoding='utf-8') as f:
         expected_output = f.read()
 
     assert output == expected_output

--- a/tests/test_unit/test_po2md/test_po2md_cli.py
+++ b/tests/test_unit/test_po2md/test_po2md_cli.py
@@ -100,7 +100,7 @@ def test_save(capsys, arg, tmp_file):
         assert f'{output}\n' == EXAMPLE['markdown-output']
         assert stdout == ''
 
-        with open(output_md_filepath) as f:
+        with open(output_md_filepath, encoding='utf-8') as f:
             assert f'{f.read()}\n' == EXAMPLE['markdown-output']
 
 

--- a/tests/test_unit/test_po2md/test_po2md_translate.py
+++ b/tests/test_unit/test_po2md/test_po2md_translate.py
@@ -30,13 +30,13 @@ def test_translate_markuptext(filename):
         filepath_in, location=False, po_filepath=po_filepath,
     )
 
-    with open(po_filepath) as f:
+    with open(po_filepath, encoding='utf-8') as f:
         pofile_content = f.read()
     assert str(pofile) == pofile_content
 
     # assert translation
     output = pofile_to_markdown(filepath_in, po_filepath)
-    with open(filepath_out) as f:
+    with open(filepath_out, encoding='utf-8') as f:
         expected_output = f.read()
     assert output == expected_output
 
@@ -53,8 +53,8 @@ def test_translate_save(filename, tmp_file):
     with tmp_file(suffix='.po') as save_filepath:
         pofile_to_markdown(filepath_in, po_filepath, save=save_filepath)
 
-        with open(save_filepath) as f:
+        with open(save_filepath, encoding='utf-8') as f:
             result = f.read()
 
-        with open(filepath_out) as expect_file:
+        with open(filepath_out, encoding='utf-8') as expect_file:
             assert result == expect_file.read()

--- a/tests/test_unit/test_po2md/test_po2md_translator.py
+++ b/tests/test_unit/test_po2md/test_po2md_translator.py
@@ -10,7 +10,7 @@ def test___slots__(class_slots):
     po2md_implementation_filepath = os.path.join(
         'src', 'mdpo', 'po2md', '__init__.py',
     )
-    with open(po2md_implementation_filepath) as f:
+    with open(po2md_implementation_filepath, encoding='utf-8') as f:
         content = f.read()
 
     for slot in slots:

--- a/tests/test_unit/test_po2md/test_po2md_wrapwidth.py
+++ b/tests/test_unit/test_po2md/test_po2md_wrapwidth.py
@@ -31,6 +31,6 @@ def test_wrapwidth(filename, wrapwidth):
 
     output = pofile_to_markdown(filepath_in, po_filepath, wrapwidth=wrapwidth)
 
-    with open(filepath_out) as f:
+    with open(filepath_out, encoding='utf-8') as f:
         expected_output = f.read()
     assert output == expected_output


### PR DESCRIPTION
Fixed edge case encoding bug in Windows when decoding PO files with `md2po`