### PR TITLE
Drop support for Python3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       matrix:
         include:
           - platform: ubuntu-latest
-            python-version: 3.7
-            py: py37
-          - platform: ubuntu-latest
             python-version: 3.8
             py: py38
           - platform: ubuntu-latest
@@ -46,9 +43,6 @@ jobs:
           - platform: ubuntu-latest
             python-version: "3.11"
             py: py311
-          - platform: macos-latest
-            python-version: 3.7
-            py: py37
           - platform: macos-latest
             python-version: 3.9
             py: py39

--- a/docs/pre-commit-hooks.rst
+++ b/docs/pre-commit-hooks.rst
@@ -19,7 +19,7 @@ so you don't need to specify them.
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v1.1.5
+           rev: v1.1.6
            hooks:
              - id: md2po
                args:
@@ -32,7 +32,7 @@ so you don't need to specify them.
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v1.1.5
+           rev: v1.1.6
            hooks:
              - id: md2po
                files: ^README\.md
@@ -53,7 +53,7 @@ po2md
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v1.1.5
+           rev: v1.1.6
            hooks:
              - id: po2md
                args:
@@ -68,7 +68,7 @@ po2md
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v1.1.5
+           rev: v1.1.6
            hooks:
              - id: po2md
                files: ^README\.md
@@ -91,7 +91,7 @@ md2po2md
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v1.1.5
+           rev: v1.1.6
            hooks:
              - id: md2po2md
                args:
@@ -107,7 +107,7 @@ md2po2md
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v1.1.5
+           rev: v1.1.6
            hooks:
              - id: md2po2md
                files: ^README\.md
@@ -126,7 +126,7 @@ mdpo2html
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v1.1.5
+           rev: v1.1.6
            hooks:
              - id: mdpo2html
                args:
@@ -141,7 +141,7 @@ mdpo2html
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/mdpo
-           rev: v1.1.5
+           rev: v1.1.6
            hooks:
              - id: mdpo2html
                files: ^README\.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "mdpo"
-version = "1.1.6"
+version = "2.0.0"
 description = "Markdown files translation using PO files."
 readme = "README.md"
 license = "BSD-3-Clause"
 authors = [{ name = "Álvaro Mondéjar Rubio", email = "mondejar1994@gmail.com" }]
-requires-python = ">=3.7,<3.13"
+requires-python = ">=3.8,<3.13"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Operating System :: OS Independent",
@@ -15,7 +15,6 @@ classifiers = [
   "Topic :: Text Processing",
   "Topic :: Text Processing :: Markup :: Markdown",
   "Environment :: Console",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -83,7 +82,7 @@ cov = [
 ]
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["py37", "py38", "py39", "py310", "py311", "py312"]
+python = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.hatch.envs.docs]
 python = "3.10"
@@ -131,7 +130,7 @@ exclude_lines = [
 
 [tool.ruff]
 line-length = 80
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mdpo"
-version = "1.1.5"
+version = "1.1.6"
 description = "Markdown files translation using PO files."
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -27,7 +27,7 @@ dependencies = [
   "polib>=1.1,<2",
   "pymd4c>=1.3,<2",
   "md-ulb-pwrap>=0.1,<1",
-  "importlib-metadata-argparse-version",
+  "importlib-metadata-argparse-version>=2,<3",
   "importlib-metadata; python_version < '3.10'",
   "contextlib-chdir>=1,<2",
 ]
@@ -109,9 +109,9 @@ targets = [{ file = "pyproject.toml" }, { file = "docs/pre-commit-hooks.rst" }]
 [tool.project-config]
 cache = "2 days"
 style = [
-  "gh://mondeja/project-config-styles@v5.2/python/base.json5",
-  "gh://mondeja/project-config-styles@v5.2/python/sphinx.json5",
-  "gh://mondeja/project-config-styles@v5.2/python/readthedocs.json5",
+  "gh://mondeja/project-config-styles@v5.2.1/python/base.json5",
+  "gh://mondeja/project-config-styles@v5.2.1/python/sphinx.json5",
+  "gh://mondeja/project-config-styles@v5.2.1/python/readthedocs.json5",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mdpo/cli.py
+++ b/src/mdpo/cli.py
@@ -128,8 +128,8 @@ def add_common_cli_first_arguments(parser, quiet=True):
     )
     parser.add_argument(
         '-v', '--version', action=ImportlibMetadataVersionAction,
+        version_from='mdpo',
         version='%(prog)s %(version)s',
-        importlib_metadata_version_from='mdpo',
         help='Show program version number and exit.',
     )
     if quiet:


### PR DESCRIPTION
This is breaking new installations because `importlib-metadata-argparse-version` v2 has been released.