### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
         id: get-version
         run: echo "version=$(cat pyproject.toml | grep "version = " -m 1 | cut -d' ' -f3 | cut -c 2- | rev | cut -c 2- | rev)" >> $GITHUB_OUTPUT
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html
@@ -53,7 +53,7 @@ jobs:
         env:
           SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run pre-commit autoupdate
         run: pre-commit autoupdate
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6.1.0
         with:
           branch: pre-commit-autoupdate
           title: Upgrade pre-commit hooks revisions


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages)** published a new release **[v4.0.0](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4.0.0)** on 2024-04-08T15:43:04Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.1.0](https://github.com/peter-evans/create-pull-request/releases/tag/v6.1.0)** on 2024-06-18T16:54:59Z
