### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           coverage xml
       - name: Upload coverage
         if: matrix.py != '3.9'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5.1.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -87,7 +87,7 @@ jobs:
         run: hatch run docs:build
         env:
           SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.5.0
         with:
           path: docs/_build/html/*
           name: docs
@@ -108,7 +108,7 @@ jobs:
         run: pip install -U hatch
       - name: Build package
         run: hatch build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.5.0
         with:
           path: dist/*
           name: wheel-sdist
@@ -164,7 +164,7 @@ jobs:
           mv dist/po2md dist/po2md-${{ matrix.runs-on }}
           mv dist/md2po2md dist/md2po2md-${{ matrix.runs-on }}
           mv dist/mdpo2html dist/mdpo2html-${{ matrix.runs-on }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.5.0
         with:
           path: dist/*
           name: ${{ matrix.runs-on }}-build
@@ -241,7 +241,7 @@ jobs:
       - name: Remove build directories
         run: rm -rf build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: dist
           path: ./dist

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
         id: get-version
         run: echo "version=$(cat pyproject.toml | grep "version = " -m 1 | cut -d' ' -f3 | cut -c 2- | rev | cut -c 2- | rev)" >> $GITHUB_OUTPUT
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html
@@ -53,7 +53,7 @@ jobs:
         env:
           SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run pre-commit autoupdate
         run: pre-commit autoupdate
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7.0.6
         with:
           branch: pre-commit-autoupdate
           title: Upgrade pre-commit hooks revisions


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.6](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.6)** on 2024-12-27T11:02:42Z
* **[peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages)** published a new release **[v4.0.0](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4.0.0)** on 2024-04-08T15:43:04Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.1.2](https://github.com/codecov/codecov-action/releases/tag/v5.1.2)** on 2024-12-18T18:45:28Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.5.0](https://github.com/actions/upload-artifact/releases/tag/v4.5.0)** on 2024-12-17T22:02:43Z
